### PR TITLE
Tighten trait tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ keywords = ["hwloc", "locality", "cache", "numa", "hardware"]
 categories = ["concurrency", "external-ffi-bindings", "hardware-support", "memory-management", "os"]
 
 [workspace.dependencies]
+enum-iterator = "1.4.1"
+quickcheck = "1.0"
+quickcheck_macros = "1.0"
+rand = "0.8"
 libc = "0.2"
 static_assertions = "1.1.0"
 windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_System_Threading"] }
@@ -157,25 +161,25 @@ num_enum = { version = "0.7", default-features = false }
 # Used to simplify error reporting
 thiserror = "1.0"
 
-# Used for random testing (tests + quickcheck feature)
-enum-iterator = { version = "1.4.1", optional = true }
-quickcheck = { version = "1.0", optional = true }
-rand = { version = "0.8", optional = true }
+# Used for optional quickcheck feature
+enum-iterator = { workspace = true, optional = true }
+quickcheck = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
 
 [dev-dependencies]
 # Used to simplify examples and test error reporting
 anyhow = { version = "1.0", features = ["backtrace"] }
 
-# Used to exhaustively test enum variants
-enum-iterator = "1.4.1"
+# Used to exhaustively test enum variants and for random testing
+enum-iterator.workspace = true
 
 # Used to ease debugging of string tests
 pretty_assertions = "1.4"
 
 # Used for random testing
-quickcheck = "1.0"
-quickcheck_macros = "1.0"
-rand = "0.8"
+quickcheck.workspace = true
+quickcheck_macros.workspace = true
+rand.workspace = true
 
 # Used to check trait implementations
 static_assertions.workspace = true

--- a/hwlocality-sys/src/lib.rs
+++ b/hwlocality-sys/src/lib.rs
@@ -203,10 +203,14 @@
 
 #[cfg(target_os = "linux")]
 use libc::pid_t;
+#[cfg(doc)]
+use std::panic::UnwindSafe;
 use std::{
+    cell::UnsafeCell,
     ffi::{c_char, c_float, c_int, c_uchar, c_uint, c_ulong, c_ushort, c_void},
     fmt::Debug,
     marker::{PhantomData, PhantomPinned},
+    panic::RefUnwindSafe,
     ptr,
 };
 
@@ -233,8 +237,9 @@ struct IncompleteType {
     /// into compiler black magic than I do, so let's keep it that way...
     _data: [u8; 0],
 
-    /// Ensures `Send`, `Sync` and `Unpin` are not implemented
-    _marker: PhantomData<(*mut u8, PhantomPinned)>,
+    /// Ensures `RefUnwindSafe`, `Send`, `Sync`, `Unpin` and `UndindSafe` are
+    /// not implemented
+    _marker: PhantomData<(*mut u8, PhantomPinned, &'static UnsafeCell<u8>)>,
 }
 
 /// Thread identifier (OS-specific)
@@ -860,7 +865,7 @@ impl Default for hwloc_numanode_attr_s {
 }
 
 /// Local memory page type
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[doc(alias = "hwloc_numanode_attr_s::hwloc_memory_page_type_s")]
 #[doc(alias = "hwloc_obj_attr_u::hwloc_numanode_attr_s::hwloc_memory_page_type_s")]
 #[repr(C)]
@@ -1096,12 +1101,27 @@ pub struct hwloc_info_s {
 ///
 /// Models the incomplete type that [`hwloc_topology_t`] API pointers map to.
 ///
-/// This type purposely implements no traits, not even Debug, because you should
-/// never, ever deal with it directly, only with raw pointers to it that you
-/// blindly pass to the hwloc API.
+/// This type purposely implements almost no traits, not even Debug, because you
+/// should never, ever deal with it directly, only with raw pointers to it that
+/// you blindly pass to the hwloc API.
+///
+/// The only exception to this rule is [`RefUnwindSafe`], which is special
+/// because...
+///
+/// - You cannot implement [`UnwindSafe`] yourself for standard pointer types
+///   due to orphan rules
+/// - Rust implements it for pointers to [`RefUnwindSafe`], i.e. it assumes you
+///   use pointers to such data responsibly.
+/// - The ergonomic impact of everyday types not being [`UnwindSafe`] is
+///   annoying (need [`AssertUnwindSafe`] in every [`catch_unwind()`]).
+///
+/// [`AssertUnwindSafe`]: std::panic::AssertUnwindSafe,
+/// [`catch_unwind()`]: std::panic::catch_unwind()
 #[allow(missing_debug_implementations)]
 #[repr(C)]
 pub struct hwloc_topology(IncompleteType);
+//
+impl RefUnwindSafe for hwloc_topology {}
 
 /// Topology context
 ///
@@ -1863,12 +1883,27 @@ pub const HWLOC_DISTRIB_FLAG_REVERSE: hwloc_distrib_flags_e = 1 << 0;
 /// Represents the private `hwloc_bitmap_s` type that `hwloc_bitmap_t` API
 /// pointers map to.
 ///
-/// This type purposely implements no traits, not even Debug, because you should
-/// never, ever deal with it directly, only with raw pointers to it that you
-/// blindly pass to the hwloc API.
+/// This type purposely implements almost no traits, not even Debug, because you
+/// should never, ever deal with it directly, only with raw pointers to it that
+/// you blindly pass to the hwloc API.
+///
+/// The only exception to this rule is [`RefUnwindSafe`], which is special
+/// because...
+///
+/// - You cannot implement [`UnwindSafe`] yourself for standard pointer types
+///   due to orphan rules
+/// - Rust implements it for pointers to [`RefUnwindSafe`], i.e. it assumes you
+///   use pointers to such data responsibly.
+/// - The ergonomic impact of everyday types not being [`UnwindSafe`] is
+///   annoying (need [`AssertUnwindSafe`] in every [`catch_unwind()`]).
+///
+/// [`AssertUnwindSafe`]: std::panic::AssertUnwindSafe,
+/// [`catch_unwind()`]: std::panic::catch_unwind()
 #[allow(missing_debug_implementations)]
 #[repr(C)]
 pub struct hwloc_bitmap_s(IncompleteType);
+//
+impl RefUnwindSafe for hwloc_bitmap_s {}
 
 /// Set of bits represented as an opaque pointer to an internal bitmap
 pub type hwloc_bitmap_t = *mut hwloc_bitmap_s;
@@ -3300,89 +3335,229 @@ extern_c_block!("hwloc");
 #[cfg(test)]
 mod tests {
     use super::*;
-    use static_assertions::assert_impl_all;
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
     use std::{
+        fmt::{
+            self, Binary, Debug, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
+        },
         hash::Hash,
+        io::{self, Read},
+        ops::{Deref, Drop},
         panic::{RefUnwindSafe, UnwindSafe},
     };
 
-    // Check that public types in this module keep implementing all expected
-    // traits, in the interest of detecting future semver-breaking changes
-    assert_impl_all!(hwloc_bridge_attr_s:
-        Clone, Copy, Debug, RefUnwindSafe, Send, Sized, Sync, Unpin, UnwindSafe
+    // Opaque types implement almost no trait since the user shouldn't
+    // manipulate them
+    assert_impl_all!(IncompleteType: Sized);
+    assert_not_impl_any!(IncompleteType:
+        Binary, Clone, Debug, Default, Deref, Display, Drop, IntoIterator,
+        LowerExp, LowerHex, Octal, PartialEq, Pointer, Read, Send, ToOwned,
+        Unpin, RefUnwindSafe, UpperExp, UpperHex, fmt::Write, io::Write
     );
-    assert_impl_all!(hwloc_cache_attr_s:
-        Clone, Copy, Debug, Default, Eq, Hash, RefUnwindSafe, Send, Sized, Sync,
-        Unpin, UnwindSafe
+    assert_impl_all!(hwloc_bitmap_s: Sized, RefUnwindSafe);
+    assert_not_impl_any!(hwloc_bitmap_s:
+        Binary, Clone, Debug, Default, Deref, Display, Drop, IntoIterator,
+        LowerExp, LowerHex, Octal, PartialEq, Pointer, Read, Send, ToOwned,
+        Unpin, UnwindSafe, UpperExp, UpperHex, fmt::Write, io::Write
     );
-    assert_impl_all!(hwloc_distances_s:
-        Clone, Copy, Debug, Default, RefUnwindSafe, Sized, Unpin, UnwindSafe
+    assert_impl_all!(hwloc_topology: Sized, RefUnwindSafe);
+    assert_not_impl_any!(hwloc_topology:
+        Binary, Clone, Debug, Default, Deref, Display, Drop, IntoIterator,
+        LowerExp, LowerHex, Octal, PartialEq, Pointer, Read, Send, ToOwned,
+        Unpin, UnwindSafe, UpperExp, UpperHex, fmt::Write, io::Write
     );
-    assert_impl_all!(hwloc_group_attr_s:
-        Clone, Copy, Debug, Default, Eq, Hash, RefUnwindSafe, Send, Sized, Sync,
-        Unpin, UnwindSafe
-    );
+
+    // Types with inner pointers that shouldn't be null and have unspecified
+    // semantics implement a basic set of traits
     assert_impl_all!(hwloc_info_s:
-        Clone, Copy, Debug, RefUnwindSafe, Sized, Unpin, UnwindSafe
+        Copy, Debug, Sized, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(hwloc_info_s:
+        Binary, Default, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex,
+        Octal, PartialEq, Pointer, Read, Send, UpperExp, UpperHex, fmt::Write,
+        io::Write
     );
     #[cfg(feature = "hwloc-2_3_0")]
-    assert_impl_all!(hwloc_location:
-        Clone, Copy, Debug, RefUnwindSafe, Sized, Unpin, UnwindSafe
+    mod hwloc_location {
+        use super::*;
+        assert_impl_all!(hwloc_location:
+            Copy, Debug, Sized, Unpin, UnwindSafe
+        );
+        assert_not_impl_any!(hwloc_location:
+            Binary, Default, Deref, Display, Drop, IntoIterator, LowerExp,
+            LowerHex, Octal, PartialEq, Pointer, Read, Send, UpperExp, UpperHex,
+            fmt::Write, io::Write
+        );
+        assert_impl_all!(hwloc_location_u:
+            Copy, Debug, Sized, Unpin, UnwindSafe
+        );
+        assert_not_impl_any!(hwloc_location_u:
+            Binary, Default, Deref, Display, Drop, IntoIterator, LowerExp,
+            LowerHex, Octal, PartialEq, Pointer, Read, Send, UpperExp, UpperHex,
+            fmt::Write, io::Write
+        );
+    }
+    assert_impl_all!(hwloc_obj:
+        Copy, Debug, Sized, Unpin, UnwindSafe
     );
-    #[cfg(feature = "hwloc-2_3_0")]
-    assert_impl_all!(hwloc_location_u:
-        Clone, Copy, Debug, RefUnwindSafe, Sized, Unpin, UnwindSafe
+    assert_not_impl_any!(hwloc_obj:
+        Binary, Default, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex,
+        Octal, PartialEq, Pointer, Read, Send, UpperExp, UpperHex, fmt::Write,
+        io::Write
     );
-    assert_impl_all!(hwloc_memory_page_type_s:
-        Clone, Copy, Debug, Default, Eq, Hash, RefUnwindSafe, Send, Sized, Sync,
-        Unpin, UnwindSafe
+
+    // Types with pointers that can reasonably be null are like types with
+    // non-nullable pointers, but also implement Default
+    assert_impl_all!(hwloc_distances_s:
+        Copy, Debug, Default, Sized, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(hwloc_distances_s:
+        Binary, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialEq, Pointer, Read, Send, UpperExp, UpperHex, fmt::Write,
+        io::Write
     );
     assert_impl_all!(hwloc_numanode_attr_s:
-        Clone, Copy, Debug, Default, RefUnwindSafe, Sized, Unpin, UnwindSafe
+        Copy, Debug, Default, Sized, Unpin, UnwindSafe
     );
-    assert_impl_all!(hwloc_obj:
-        Clone, Copy, Debug, RefUnwindSafe, Sized, Unpin, UnwindSafe
+    assert_not_impl_any!(hwloc_numanode_attr_s:
+        Binary, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialEq, Pointer, Read, Send, UpperExp, UpperHex, fmt::Write,
+        io::Write
     );
+    assert_impl_all!(hwloc_topology_support:
+        Copy, Debug, Default, Sized, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(hwloc_topology_support:
+        Binary, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialEq, Pointer, Read, Send, UpperExp, UpperHex, fmt::Write,
+        io::Write
+    );
+
+    // As the union of all attribute structs, hwloc_obj_attr_u can only
+    // implement the common subset of their inner traits. It also cannot
+    // implement any trait that requires looking into the active variant since
+    // it doesn't know what the active variant is, nor if there is even one.
     assert_impl_all!(hwloc_obj_attr_u:
-        Clone, Copy, Debug, RefUnwindSafe, Sized, Unpin, UnwindSafe
+        Copy, Debug, Sized, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(hwloc_obj_attr_u:
+        Binary, Default, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex,
+        Octal, PartialEq, Pointer, Read, Send, UpperExp, UpperHex, fmt::Write,
+        io::Write
+    );
+
+    // Unions that contain only Sync types can additionally impl Sync, and this
+    // also applies to types that contain such unions
+    assert_impl_all!(hwloc_bridge_attr_s:
+        Copy, Debug, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(hwloc_bridge_attr_s:
+        Binary, Default, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex,
+        Octal, PartialEq, Pointer, Read, UpperExp, UpperHex, fmt::Write,
+        io::Write
+    );
+    assert_impl_all!(RawDownstreamAttributes:
+        Copy, Debug, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(RawDownstreamAttributes:
+        Binary, Default, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex,
+        Octal, PartialEq, Pointer, Read, UpperExp, UpperHex, fmt::Write,
+        io::Write
+    );
+    assert_impl_all!(RawUpstreamAttributes:
+        Copy, Debug, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(RawUpstreamAttributes:
+        Binary, Default, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex,
+        Octal, PartialEq, Pointer, Read, UpperExp, UpperHex, fmt::Write,
+        io::Write
+    );
+
+    // Most plain old data structs implement Default, Sync and comparisons
+    //
+    // Implemented comparisons are mostly equality+hashing and not order, since
+    // ordering random structs with unrelated members doesn't make much sense.
+    // We make an exception for hwloc_memory_page_type_s which has an officially
+    // defined order.
+    assert_impl_all!(hwloc_cache_attr_s:
+        Copy, Debug, Default, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(hwloc_cache_attr_s:
+        Binary, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialOrd, Pointer, Read, UpperExp, UpperHex, fmt::Write, io::Write
+    );
+    assert_impl_all!(hwloc_group_attr_s:
+        Copy, Debug, Default, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(hwloc_group_attr_s:
+        Binary, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialOrd, Pointer, Read, UpperExp, UpperHex, fmt::Write, io::Write
     );
     assert_impl_all!(hwloc_osdev_attr_s:
-        Clone, Copy, Debug, Default, Eq, Hash, RefUnwindSafe, Send, Sized, Sync,
-        Unpin, UnwindSafe
+        Copy, Debug, Default, Hash, Sized, Sync, Unpin, UnwindSafe
     );
-    assert_impl_all!(hwloc_pcidev_attr_s:
-        Clone, Copy, Debug, Default, PartialEq, RefUnwindSafe, Send, Sized,
-        Sync, Unpin, UnwindSafe
+    assert_not_impl_any!(hwloc_osdev_attr_s:
+        Binary, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialOrd, Pointer, Read, UpperExp, UpperHex, fmt::Write, io::Write
     );
     assert_impl_all!(hwloc_topology_cpubind_support:
-        Clone, Copy, Debug, Default, Eq, Hash, RefUnwindSafe, Send, Sized, Sync,
-        Unpin, UnwindSafe
+        Copy, Debug, Default, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(hwloc_topology_cpubind_support:
+        Binary, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialOrd, Pointer, Read, UpperExp, UpperHex, fmt::Write, io::Write
     );
     assert_impl_all!(hwloc_topology_discovery_support:
-        Clone, Copy, Debug, Default, Eq, Hash, RefUnwindSafe, Send, Sized, Sync,
-        Unpin, UnwindSafe
+        Copy, Debug, Default, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(hwloc_topology_discovery_support:
+        Binary, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialOrd, Pointer, Read, UpperExp, UpperHex, fmt::Write, io::Write
     );
     assert_impl_all!(hwloc_topology_membind_support:
-        Clone, Copy, Debug, Default, Eq, Hash, RefUnwindSafe, Send, Sized, Sync,
-        Unpin, UnwindSafe
+        Copy, Debug, Default, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(hwloc_topology_membind_support:
+        Binary, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialOrd, Pointer, Read, UpperExp, UpperHex, fmt::Write, io::Write
     );
     #[cfg(feature = "hwloc-2_3_0")]
     assert_impl_all!(hwloc_topology_misc_support:
-        Clone, Copy, Debug, Default, Eq, Hash, RefUnwindSafe, Send, Sized, Sync,
-        Unpin, UnwindSafe
+        Copy, Debug, Default, Hash, Sized, Sync, Unpin, UnwindSafe
     );
-    assert_impl_all!(hwloc_topology_support:
-        Clone, Copy, Debug, Default, RefUnwindSafe, Sized, Unpin, UnwindSafe
-    );
-    assert_impl_all!(RawDownstreamAttributes:
-        Clone, Copy, Debug, RefUnwindSafe, Send, Sized, Sync, Unpin, UnwindSafe
+    #[cfg(feature = "hwloc-2_3_0")]
+    assert_not_impl_any!(hwloc_topology_misc_support:
+        Binary, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialOrd, Pointer, Read, UpperExp, UpperHex, fmt::Write, io::Write
     );
     assert_impl_all!(RawDownstreamPCIAttributes:
-        Clone, Copy, Debug, Default, Eq, Hash, RefUnwindSafe, Send, Sized, Sync,
-        Unpin, UnwindSafe
+        Copy, Debug, Default, Hash, Sized, Sync, Unpin, UnwindSafe
     );
-    assert_impl_all!(RawUpstreamAttributes:
-        Clone, Copy, Debug, RefUnwindSafe, Send, Sized, Sync, Unpin, UnwindSafe
+    assert_not_impl_any!(RawDownstreamPCIAttributes:
+        Binary, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialOrd, Pointer, Read, UpperExp, UpperHex, fmt::Write, io::Write
+    );
+
+    // hwloc_memory_page_type_s has an officially defined order and has its
+    // comparison abilities expanded accordingly
+    assert_impl_all!(hwloc_memory_page_type_s:
+        Copy, Debug, Default, Hash, Ord, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(hwloc_memory_page_type_s:
+        Binary, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        Pointer, Read, UpperExp, UpperHex, fmt::Write, io::Write
+    );
+
+    // PCIDevice attributes, contain a floating-point value and have their
+    // comparison abilities restricted accordingly
+    assert_impl_all!(hwloc_pcidev_attr_s:
+        Copy, Debug, Default, PartialEq, Sized, Sync, Unpin,
+        UnwindSafe
+    );
+    assert_not_impl_any!(hwloc_pcidev_attr_s:
+        Binary, Deref, Display, Drop, Eq, IntoIterator, LowerExp, LowerHex,
+        Octal, PartialOrd, Pointer, Read, UpperExp, UpperHex, fmt::Write,
+        io::Write
     );
 
     #[test]

--- a/hwlocality-sys/src/lib.rs
+++ b/hwlocality-sys/src/lib.rs
@@ -1115,7 +1115,7 @@ pub struct hwloc_info_s {
 /// - The ergonomic impact of everyday types not being [`UnwindSafe`] is
 ///   annoying (need [`AssertUnwindSafe`] in every [`catch_unwind()`]).
 ///
-/// [`AssertUnwindSafe`]: std::panic::AssertUnwindSafe,
+/// [`AssertUnwindSafe`]: std::panic::AssertUnwindSafe
 /// [`catch_unwind()`]: std::panic::catch_unwind()
 #[allow(missing_debug_implementations)]
 #[repr(C)]
@@ -1897,7 +1897,7 @@ pub const HWLOC_DISTRIB_FLAG_REVERSE: hwloc_distrib_flags_e = 1 << 0;
 /// - The ergonomic impact of everyday types not being [`UnwindSafe`] is
 ///   annoying (need [`AssertUnwindSafe`] in every [`catch_unwind()`]).
 ///
-/// [`AssertUnwindSafe`]: std::panic::AssertUnwindSafe,
+/// [`AssertUnwindSafe`]: std::panic::AssertUnwindSafe
 /// [`catch_unwind()`]: std::panic::catch_unwind()
 #[allow(missing_debug_implementations)]
 #[repr(C)]
@@ -3378,7 +3378,7 @@ mod tests {
         io::Write
     );
     #[cfg(feature = "hwloc-2_3_0")]
-    mod hwloc_location {
+    mod hwloc_location_impls {
         use super::*;
         assert_impl_all!(hwloc_location:
             Copy, Debug, Sized, Unpin, UnwindSafe

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -2907,7 +2907,7 @@ macro_rules! impl_bitmap_newtype_tests {
                     format!("{new:?}"),
                     format!("{}({:?})", stringify!($newtype), new.0)
                 );
-                assert_eq!(format!("{new:p}"), format!("{:p}", new.0));
+                assert_eq!(format!("{:p}", new), format!("{:p}", new.0));
                 assert_eq!(
                     new.to_string(),
                     format!("{}({})", stringify!($newtype), new.0)
@@ -3330,7 +3330,7 @@ pub(crate) mod tests {
     }
 
     fn test_basic_inplace(initial: &Bitmap, inverse: &Bitmap) {
-        assert_eq!(format!("{initial:p}"), format!("{:p}", initial.0));
+        assert_eq!(format!("{:p}", *initial), format!("{:p}", initial.0));
 
         let mut buf = initial.clone();
         buf.clear();

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -74,7 +74,7 @@ use std::{
     cmp::Ordering,
     convert::TryFrom,
     ffi::{c_int, c_uint},
-    fmt::{self, Debug, Display},
+    fmt::{self, Debug, Display, Pointer},
     hash::{self, Hash},
     iter::{FromIterator, FusedIterator},
     marker::PhantomData,
@@ -1451,7 +1451,7 @@ impl Hash for Bitmap {
 }
 
 /// Iterator over set or unset [`Bitmap`] indices
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Iter<B> {
     /// Bitmap over which we're iterating
     bitmap: B,
@@ -1564,6 +1564,12 @@ impl<B: Borrow<Self>> PartialEq<B> for Bitmap {
 impl<B: Borrow<Self>> PartialOrd<B> for Bitmap {
     fn partial_cmp(&self, other: &B) -> Option<Ordering> {
         Some(self.cmp(other.borrow()))
+    }
+}
+
+impl Pointer for Bitmap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <NonNull<hwloc_bitmap_s> as fmt::Pointer>::fmt(&self.0, f)
     }
 }
 
@@ -1952,7 +1958,7 @@ where
     }
 }
 
-impl<Target> fmt::Pointer for BitmapRef<'_, Target> {
+impl<Target> Pointer for BitmapRef<'_, Target> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         <NonNull<hwloc_bitmap_s> as fmt::Pointer>::fmt(&self.0, f)
     }
@@ -2591,6 +2597,12 @@ macro_rules! impl_bitmap_newtype {
             }
         }
 
+        impl std::fmt::Pointer for $newtype {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                <$crate::bitmap::Bitmap as std::fmt::Pointer>::fmt(&self.0, f)
+            }
+        }
+
         impl $crate::Sealed for $newtype {}
 
         impl<B: std::borrow::Borrow<$newtype>> std::ops::Sub<B> for &$newtype {
@@ -2649,17 +2661,20 @@ macro_rules! impl_bitmap_newtype_tests {
             use std::{
                 borrow::{Borrow, BorrowMut},
                 collections::hash_map::DefaultHasher,
-                fmt::{Debug, Display, Pointer},
+                fmt::{
+                    self, Binary, Debug, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
+                },
                 hash::{Hash, Hasher},
+                io::{self, Read},
                 mem::ManuallyDrop,
                 ops::{
-                    BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor,
-                    BitXorAssign, Deref, Not, RangeInclusive, Sub, SubAssign
+                    BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, Deref, Drop,
+                    BitXorAssign, Not, RangeInclusive, Sub, SubAssign
                 },
-                panic::{RefUnwindSafe, UnwindSafe},
+                panic::{UnwindSafe},
                 ptr::{self, NonNull}
             };
-            use static_assertions::assert_impl_all;
+            use static_assertions::{assert_impl_all, assert_not_impl_any};
 
             // Check that newtypes keep implementing all expected traits,
             // in the interest of detecting future semver-breaking changes
@@ -2695,7 +2710,7 @@ macro_rules! impl_bitmap_newtype_tests {
                 PartialOrd<&'static $newtype>,
                 PartialOrd<BitmapRef<'static, $newtype>>,
                 PartialOrd<&'static BitmapRef<'static, $newtype>>,
-                RefUnwindSafe, Send, Sized,
+                Pointer, Sized,
                 Sub<$newtype>, Sub<&'static $newtype>,
                 Sub<BitmapRef<'static, $newtype>>,
                 Sub<&'static BitmapRef<'static, $newtype>>,
@@ -2703,6 +2718,10 @@ macro_rules! impl_bitmap_newtype_tests {
                 SubAssign<BitmapRef<'static, $newtype>>,
                 SubAssign<&'static BitmapRef<'static, $newtype>>,
                 Sync, Unpin, UnwindSafe
+            );
+            assert_not_impl_any!($newtype:
+                Binary, Copy, Deref, LowerExp, LowerHex, Octal, Read, UpperExp,
+                UpperHex, fmt::Write, io::Write
             );
             assert_impl_all!(&$newtype:
                 BitAnd<$newtype>, BitAnd<&'static $newtype>,
@@ -2714,12 +2733,11 @@ macro_rules! impl_bitmap_newtype_tests {
                 BitXor<$newtype>, BitXor<&'static $newtype>,
                 BitXor<BitmapRef<'static, $newtype>>,
                 BitXor<&'static BitmapRef<'static, $newtype>>,
-                Clone, Debug, Display, Hash, IntoIterator<Item=BitmapIndex>,
-                Not<Output=$newtype>, RefUnwindSafe, Send, Sized,
+                IntoIterator<Item=BitmapIndex>,
+                Not<Output=$newtype>,
                 Sub<$newtype>, Sub<&'static $newtype>,
                 Sub<BitmapRef<'static, $newtype>>,
                 Sub<&'static BitmapRef<'static, $newtype>>,
-                Sync, Unpin, UnwindSafe
             );
             assert_impl_all!(BitmapRef<'static, $newtype>:
                 AsRef<$newtype>, AsRef<Bitmap>,
@@ -2732,7 +2750,7 @@ macro_rules! impl_bitmap_newtype_tests {
                 BitXor<$newtype>, BitXor<&'static $newtype>,
                 BitXor<BitmapRef<'static, $newtype>>,
                 BitXor<&'static BitmapRef<'static, $newtype>>,
-                Borrow<$newtype>, Borrow<Bitmap>, Clone, Debug,
+                Borrow<$newtype>, Borrow<Bitmap>, Copy, Debug,
                 Deref<Target=$newtype>, Display, Eq, From<&'static $newtype>,
                 Hash, Into<BitmapRef<'static, Bitmap>>,
                 IntoIterator<Item=BitmapIndex>, Not<Output=$newtype>, Ord,
@@ -2742,12 +2760,15 @@ macro_rules! impl_bitmap_newtype_tests {
                 PartialOrd<&'static $newtype>,
                 PartialOrd<BitmapRef<'static, $newtype>>,
                 PartialOrd<&'static BitmapRef<'static, $newtype>>,
-                Pointer, RefUnwindSafe, Send, Sized,
-                SpecializedBitmap<Owned=$newtype>,
+                Pointer, Sized, SpecializedBitmap<Owned=$newtype>,
                 Sub<$newtype>, Sub<&'static $newtype>,
                 Sub<BitmapRef<'static, $newtype>>,
                 Sub<&'static BitmapRef<'static, $newtype>>,
                 Sync, Unpin, UnwindSafe
+            );
+            assert_not_impl_any!(BitmapRef<'_, $newtype>:
+                Binary, Default, Drop, LowerExp, LowerHex, Octal, Read,
+                UpperExp, UpperHex, fmt::Write, io::Write
             );
             assert_impl_all!(&BitmapRef<'static, $newtype>:
                 BitAnd<$newtype>, BitAnd<&'static $newtype>,
@@ -2759,12 +2780,11 @@ macro_rules! impl_bitmap_newtype_tests {
                 BitXor<$newtype>, BitXor<&'static $newtype>,
                 BitXor<BitmapRef<'static, $newtype>>,
                 BitXor<&'static BitmapRef<'static, $newtype>>,
-                Clone, Debug, Display, Hash, IntoIterator<Item=BitmapIndex>,
-                Not<Output=$newtype>, RefUnwindSafe, Send, Sized,
+                IntoIterator<Item=BitmapIndex>,
+                Not<Output=$newtype>,
                 Sub<$newtype>, Sub<&'static $newtype>,
                 Sub<BitmapRef<'static, $newtype>>,
                 Sub<&'static BitmapRef<'static, $newtype>>,
-                Sync, Unpin, UnwindSafe
             );
 
             /// Compute the hash of something
@@ -3115,20 +3135,28 @@ pub(crate) mod tests {
     #[allow(unused)]
     use pretty_assertions::{assert_eq, assert_ne};
     use quickcheck_macros::quickcheck;
-    use static_assertions::assert_impl_all;
+    use static_assertions::{
+        assert_eq_align, assert_eq_size, assert_impl_all, assert_not_impl_any, assert_type_eq_all,
+    };
     use std::{
         collections::{hash_map::DefaultHasher, HashSet},
         ffi::c_ulonglong,
-        fmt::{Pointer, Write},
-        hash::Hasher,
+        fmt::{
+            self, Binary, Debug, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
+            Write,
+        },
+        hash::{Hash, Hasher},
+        io::{self, Read},
         mem::ManuallyDrop,
-        ops::{Range, RangeFrom, RangeInclusive},
-        panic::{RefUnwindSafe, UnwindSafe},
+        ops::{Deref, Drop, Range, RangeFrom, RangeInclusive},
+        panic::UnwindSafe,
         ptr,
     };
 
     // Check that public types in this module keep implementing all expected
     // traits, in the interest of detecting future semver-breaking changes
+    assert_eq_align!(Bitmap, NonNull<hwloc_bitmap_s>);
+    assert_eq_size!(Bitmap, NonNull<hwloc_bitmap_s>);
     assert_impl_all!(Bitmap:
         BitAnd<Bitmap>, BitAnd<&'static Bitmap>,
         BitAnd<BitmapRef<'static, Bitmap>>,
@@ -3148,7 +3176,7 @@ pub(crate) mod tests {
         BitXorAssign<Bitmap>, BitXorAssign<&'static Bitmap>,
         BitXorAssign<BitmapRef<'static, Bitmap>>,
         BitXorAssign<&'static BitmapRef<'static, Bitmap>>,
-        Clone, Debug, Default, Display, Eq,
+        Clone, Debug, Default, Display,
         Extend<BitmapIndex>, Extend<&'static BitmapIndex>,
         From<BitmapIndex>, From<&'static BitmapIndex>,
         FromIterator<BitmapIndex>, FromIterator<&'static BitmapIndex>,
@@ -3159,7 +3187,7 @@ pub(crate) mod tests {
         PartialOrd<&'static Bitmap>,
         PartialOrd<BitmapRef<'static, Bitmap>>,
         PartialOrd<&'static BitmapRef<'static, Bitmap>>,
-        RefUnwindSafe, Send, Sized,
+        Pointer, Sized,
         Sub<Bitmap>, Sub<&'static Bitmap>,
         Sub<BitmapRef<'static, Bitmap>>,
         Sub<&'static BitmapRef<'static, Bitmap>>,
@@ -3167,6 +3195,10 @@ pub(crate) mod tests {
         SubAssign<BitmapRef<'static, Bitmap>>,
         SubAssign<&'static BitmapRef<'static, Bitmap>>,
         Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(Bitmap:
+        Binary, Copy, Deref, LowerExp, LowerHex, Octal, Read, UpperExp,
+        UpperHex, fmt::Write, io::Write
     );
     assert_impl_all!(&Bitmap:
         BitAnd<Bitmap>, BitAnd<&'static Bitmap>,
@@ -3178,13 +3210,14 @@ pub(crate) mod tests {
         BitXor<Bitmap>, BitXor<&'static Bitmap>,
         BitXor<BitmapRef<'static, Bitmap>>,
         BitXor<&'static BitmapRef<'static, Bitmap>>,
-        Clone, Debug, Display, Hash, IntoIterator<Item=BitmapIndex>,
-        Not<Output=Bitmap>, RefUnwindSafe, Send, Sized,
+        IntoIterator<Item=BitmapIndex>,
+        Not<Output=Bitmap>,
         Sub<Bitmap>, Sub<&'static Bitmap>,
         Sub<BitmapRef<'static, Bitmap>>,
         Sub<&'static BitmapRef<'static, Bitmap>>,
-        Sync, Unpin, UnwindSafe
     );
+    assert_eq_align!(BitmapRef<'static, Bitmap>, NonNull<hwloc_bitmap_s>);
+    assert_eq_size!(BitmapRef<'static, Bitmap>, NonNull<hwloc_bitmap_s>);
     assert_impl_all!(BitmapRef<'static, Bitmap>:
         AsRef<Bitmap>,
         BitAnd<Bitmap>, BitAnd<&'static Bitmap>,
@@ -3196,8 +3229,8 @@ pub(crate) mod tests {
         BitXor<Bitmap>, BitXor<&'static Bitmap>,
         BitXor<BitmapRef<'static, Bitmap>>,
         BitXor<&'static BitmapRef<'static, Bitmap>>,
-        Borrow<Bitmap>, Clone, Debug,
-        Deref<Target=Bitmap>, Display, Eq, From<&'static Bitmap>, Hash,
+        Borrow<Bitmap>, Copy, Debug,
+        Deref<Target=Bitmap>, Display, From<&'static Bitmap>, Hash,
         IntoIterator<Item=BitmapIndex>, Not<Output=Bitmap>, Ord,
         PartialEq<&'static Bitmap>,
         PartialEq<BitmapRef<'static, Bitmap>>,
@@ -3205,11 +3238,15 @@ pub(crate) mod tests {
         PartialOrd<&'static Bitmap>,
         PartialOrd<BitmapRef<'static, Bitmap>>,
         PartialOrd<&'static BitmapRef<'static, Bitmap>>,
-        Pointer, RefUnwindSafe, Send, Sized,
+        Pointer, Sized,
         Sub<Bitmap>, Sub<&'static Bitmap>,
         Sub<BitmapRef<'static, Bitmap>>,
         Sub<&'static BitmapRef<'static, Bitmap>>,
         Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(BitmapRef<'_, Bitmap>:
+        Binary, Default, Drop, LowerExp, LowerHex, Octal, Read, UpperExp,
+        UpperHex, fmt::Write, io::Write
     );
     assert_impl_all!(&BitmapRef<'static, Bitmap>:
         BitAnd<Bitmap>, BitAnd<&'static Bitmap>,
@@ -3221,25 +3258,37 @@ pub(crate) mod tests {
         BitXor<Bitmap>, BitXor<&'static Bitmap>,
         BitXor<BitmapRef<'static, Bitmap>>,
         BitXor<&'static BitmapRef<'static, Bitmap>>,
-        Clone, Debug, Display, Hash, IntoIterator<Item=BitmapIndex>,
-        Not<Output=Bitmap>, RefUnwindSafe, Send, Sized,
+        IntoIterator<Item=BitmapIndex>,
+        Not<Output=Bitmap>,
         Sub<Bitmap>, Sub<&'static Bitmap>,
         Sub<BitmapRef<'static, Bitmap>>,
         Sub<&'static BitmapRef<'static, Bitmap>>,
-        Sync, Unpin, UnwindSafe
     );
     assert_impl_all!(Iter<Bitmap>:
-        Clone, Debug, FusedIterator<Item=BitmapIndex>, RefUnwindSafe, Send,
-        Sized, Sync, Unpin, UnwindSafe
-    );
-    assert_impl_all!(Iter<&Bitmap>:
-        Clone, Copy, Debug, FusedIterator<Item=BitmapIndex>, RefUnwindSafe,
-        Send, Sized, Sync, Unpin, UnwindSafe
-    );
-    assert_impl_all!(BitmapKind:
-        Clone, Copy, Debug, Eq, Hash, RefUnwindSafe, Send, Sized, Sync, Unpin,
+        Clone, Debug, FusedIterator<Item=BitmapIndex>, Hash, Sized, Sync, Unpin,
         UnwindSafe
     );
+    assert_not_impl_any!(Iter<Bitmap>:
+        Binary, Copy, Default, Deref, Display, LowerExp, LowerHex, Octal,
+        Pointer, Read, UpperExp, UpperHex, fmt::Write, io::Write
+    );
+    assert_impl_all!(Iter<&Bitmap>:
+        Copy, Debug, FusedIterator<Item=BitmapIndex>, Hash, Sized, Sync, Unpin,
+        UnwindSafe
+    );
+    assert_not_impl_any!(Iter<&Bitmap>:
+        Binary, Default, Deref, Display, LowerExp, LowerHex, Octal, Pointer,
+        Read, UpperExp, UpperHex, fmt::Write, io::Write
+    );
+    assert_impl_all!(BitmapKind:
+        Copy, Debug, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(BitmapKind:
+        Binary, Default, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex,
+        Octal, PartialOrd, Pointer, Read, UpperExp, UpperHex, fmt::Write,
+        io::Write
+    );
+    assert_type_eq_all!(BitmapIndex, PositiveInt);
 
     // We can't fully check the value of infinite iterators because that would
     // literally take forever, so we only check a small subrange of the final

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -2907,6 +2907,7 @@ macro_rules! impl_bitmap_newtype_tests {
                     format!("{new:?}"),
                     format!("{}({:?})", stringify!($newtype), new.0)
                 );
+                assert_eq!(format!("{new:p}"), format!("{:p}", new.0));
                 assert_eq!(
                     new.to_string(),
                     format!("{}({})", stringify!($newtype), new.0)
@@ -3329,6 +3330,8 @@ pub(crate) mod tests {
     }
 
     fn test_basic_inplace(initial: &Bitmap, inverse: &Bitmap) {
+        assert_eq!(format!("{initial:p}"), format!("{:p}", initial.0));
+
         let mut buf = initial.clone();
         buf.clear();
         assert!(buf.is_empty());

--- a/src/ffi/int.rs
+++ b/src/ffi/int.rs
@@ -3397,13 +3397,15 @@ mod tests {
     #[allow(unused)]
     use pretty_assertions::{assert_eq, assert_ne};
     use quickcheck_macros::quickcheck;
-    use static_assertions::assert_impl_all;
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
     use std::{
         collections::hash_map::DefaultHasher,
         ffi::c_uint,
-        fmt::{Binary, Display, LowerExp, LowerHex, Octal, UpperExp, UpperHex},
+        fmt::{self, Binary, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex},
         hash::{Hash, Hasher},
+        io::{self, Read},
         num::IntErrorKind,
+        ops::Deref,
         panic::{RefUnwindSafe, UnwindSafe},
     };
 
@@ -3427,17 +3429,17 @@ mod tests {
         BitXorAssign<PositiveInt>, BitXorAssign<&'static PositiveInt>,
         BitXor<usize>, BitXor<&'static usize>,
         BitXorAssign<usize>, BitXorAssign<&'static usize>,
-        Clone, Copy, Debug, Default, Display,
+        Copy, Debug, Default, Display,
         Div<PositiveInt>, Div<&'static PositiveInt>,
         DivAssign<PositiveInt>, DivAssign<&'static PositiveInt>,
         Div<usize>, Div<&'static usize>,
         DivAssign<usize>, DivAssign<&'static usize>,
-        Eq, FromStr, Hash, Into<isize>, Into<usize>, LowerExp, LowerHex,
+        FromStr, Hash, Into<isize>, Into<usize>, LowerExp, LowerHex,
         Mul<PositiveInt>, Mul<&'static PositiveInt>,
         MulAssign<PositiveInt>, MulAssign<&'static PositiveInt>,
         Mul<usize>, Mul<&'static usize>,
         MulAssign<usize>, MulAssign<&'static usize>,
-        Not, Octal, Ord, Product, RefUnwindSafe, Send, Sized,
+        Not, Octal, Ord, Product, Sized,
         Rem<PositiveInt>, Rem<&'static PositiveInt>,
         RemAssign<PositiveInt>, RemAssign<&'static PositiveInt>,
         Rem<usize>, Rem<&'static usize>,
@@ -3507,23 +3509,22 @@ mod tests {
         TryInto<i128>, TryInto<u128>,
         Unpin, UnwindSafe, UpperExp, UpperHex
     );
+    assert_not_impl_any!(PositiveInt:
+        Deref, Drop, IntoIterator, Pointer, Read, fmt::Write, io::Write
+    );
     assert_impl_all!(&PositiveInt:
         Add<PositiveInt>, Add<&'static PositiveInt>,
         Add<isize>, Add<&'static isize>,
-        Binary,
         BitAnd<PositiveInt>, BitAnd<&'static PositiveInt>,
         BitAnd<usize>, BitAnd<&'static usize>,
         BitOr<PositiveInt>, BitOr<&'static PositiveInt>,
         BitOr<usize>, BitOr<&'static usize>,
         BitXor<PositiveInt>, BitXor<&'static PositiveInt>,
         BitXor<usize>, BitXor<&'static usize>,
-        Clone, Copy, Debug, Display,
         Div<PositiveInt>, Div<&'static PositiveInt>,
         Div<usize>, Div<&'static usize>,
-        Eq, Hash, LowerExp, LowerHex,
         Mul<PositiveInt>, Mul<&'static PositiveInt>,
         Mul<usize>, Mul<&'static usize>,
-        Not, Octal, Ord, RefUnwindSafe, Send, Sized,
         Rem<PositiveInt>, Rem<&'static PositiveInt>,
         Rem<usize>, Rem<&'static usize>,
         Shl<PositiveInt>, Shl<&'static PositiveInt>,
@@ -3555,7 +3556,6 @@ mod tests {
         Shr<PositiveInt>, Shr<&'static PositiveInt>,
         Sub<PositiveInt>, Sub<&'static PositiveInt>,
         Sub<isize>, Sub<&'static isize>,
-        Sync, Unpin, UnwindSafe, UpperExp, UpperHex
     );
 
     /// Inner bits of [`PositiveInt`] that are not used by the implementation

--- a/src/info.rs
+++ b/src/info.rs
@@ -118,19 +118,28 @@ mod tests {
     #[allow(unused)]
     use pretty_assertions::{assert_eq, assert_ne};
     use quickcheck_macros::quickcheck;
-    use static_assertions::assert_impl_all;
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
     use std::{
         collections::hash_map::RandomState,
         ffi::CString,
-        fmt::Debug,
-        hash::{BuildHasher, Hasher},
-        panic::{RefUnwindSafe, UnwindSafe},
+        fmt::{
+            self, Binary, Debug, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
+        },
+        hash::{BuildHasher, Hash, Hasher},
+        io::{self, Read},
+        ops::{Deref, Drop},
+        panic::UnwindSafe,
     };
 
     // Check that public types in this module keep implementing all expected
     // traits, in the interest of detecting future semver-breaking changes
     assert_impl_all!(TextualInfo:
-        Debug, Eq, Hash, RefUnwindSafe, Send, Sized, Sync, Unpin, UnwindSafe
+        Debug, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(TextualInfo:
+        Binary, Clone, Default, Deref, Display, Drop, IntoIterator,
+        LowerExp, LowerHex, Octal, PartialOrd, Pointer, Read, ToOwned,
+        UpperExp, UpperHex, fmt::Write, io::Write
     );
 
     #[quickcheck]

--- a/src/path.rs
+++ b/src/path.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use thiserror::Error;
 
 /// Requested file path is not suitable for hwloc consumption
-#[derive(Copy, Clone, Debug, Error, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Error, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum PathError {
     /// Path contains the NUL char, and is thus not compatible with C
     #[error("hwloc file paths can't contain NUL chars")]
@@ -55,20 +55,25 @@ mod tests {
     #[allow(unused)]
     use pretty_assertions::{assert_eq, assert_ne};
     use quickcheck_macros::quickcheck;
-    use static_assertions::assert_impl_all;
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
     use std::{
         error::Error,
-        fmt::Debug,
+        fmt::{self, Binary, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex},
         hash::Hash,
-        panic::{RefUnwindSafe, UnwindSafe},
+        io::{self, Read},
+        ops::Deref,
+        panic::UnwindSafe,
         path::PathBuf,
     };
 
     // Check that public types in this module keep implementing all expected
     // traits, in the interest of detecting future semver-breaking changes
     assert_impl_all!(PathError:
-        Clone, Copy, Debug, Error, Eq, From<NulError>, Hash, RefUnwindSafe,
-        Send, Sized, Sync, Unpin, UnwindSafe
+        Copy, Error, From<NulError>, Hash, Ord, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(PathError:
+        Binary, Default, Deref, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        Pointer, Read, UpperExp, UpperHex, fmt::Write, io::Write
     );
 
     #[allow(clippy::option_if_let_else)]

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -1121,6 +1121,7 @@ pub(crate) mod tests {
     }
 
     fn check_default_builder(builder: &TopologyBuilder) {
+        assert_eq!(format!("{builder:p}"), format!("{:p}", builder.0));
         assert_eq!(builder.flags(), BuildFlags::default());
         for object_type in enum_iterator::all::<ObjectType>() {
             assert_eq!(
@@ -1144,6 +1145,7 @@ pub(crate) mod tests {
         build_flags: BuildFlags,
         type_filter: impl Fn(ObjectType) -> TypeFilter,
     ) {
+        assert_eq!(format!("{topology:p}"), format!("{:p}", topology.0));
         assert!(topology.is_abi_compatible());
         assert_eq!(topology.build_flags(), build_flags);
         assert_eq!(

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -1054,6 +1054,14 @@ pub(crate) mod tests {
         Display, Drop, PartialOrd, Pointer, LowerExp, Read, UpperExp,
         fmt::Write, io::Write
     );
+    assert_impl_all!(FileInputError:
+        Clone, Error, From<PathError>, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(FileInputError:
+        Binary, Copy, Default, Deref, Drop, IntoIterator,
+        LowerExp, LowerHex, Octal, PartialOrd, Pointer, Read,
+        UpperExp, UpperHex, fmt::Write, io::Write
+    );
     assert_impl_all!(FromPIDError:
         Copy, Default, Error, From<ProcessId>, Hash, Sized, Sync, Unpin,
         UnwindSafe
@@ -1092,14 +1100,6 @@ pub(crate) mod tests {
     );
     assert_not_impl_any!(TypeFilterError:
         Binary, Default, Deref, Drop, IntoIterator,
-        LowerExp, LowerHex, Octal, PartialOrd, Pointer, Read,
-        UpperExp, UpperHex, fmt::Write, io::Write
-    );
-    assert_impl_all!(FileInputError:
-        Clone, Error, From<PathError>, Hash, Sized, Sync, Unpin, UnwindSafe
-    );
-    assert_not_impl_any!(FileInputError:
-        Binary, Copy, Default, Deref, Drop, IntoIterator,
         LowerExp, LowerHex, Octal, PartialOrd, Pointer, Read,
         UpperExp, UpperHex, fmt::Write, io::Write
     );

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -1121,7 +1121,7 @@ pub(crate) mod tests {
     }
 
     fn check_default_builder(builder: &TopologyBuilder) {
-        assert_eq!(format!("{builder:p}"), format!("{:p}", builder.0));
+        assert_eq!(format!("{:p}", *builder), format!("{:p}", builder.0));
         assert_eq!(builder.flags(), BuildFlags::default());
         for object_type in enum_iterator::all::<ObjectType>() {
             assert_eq!(
@@ -1145,7 +1145,7 @@ pub(crate) mod tests {
         build_flags: BuildFlags,
         type_filter: impl Fn(ObjectType) -> TypeFilter,
     ) {
-        assert_eq!(format!("{topology:p}"), format!("{:p}", topology.0));
+        assert_eq!(format!("{:p}", *topology), format!("{:p}", topology.0));
         assert!(topology.is_abi_compatible());
         assert_eq!(topology.build_flags(), build_flags);
         assert_eq!(

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -56,6 +56,7 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 #[cfg(test)]
 use pretty_assertions::{assert_eq, assert_ne};
 use std::{
+    fmt::{self, Pointer},
     path::{Path, PathBuf},
     ptr::NonNull,
 };
@@ -1002,6 +1003,12 @@ impl Drop for TopologyBuilder {
     }
 }
 
+impl Pointer for TopologyBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <NonNull<hwloc_topology> as Pointer>::fmt(&self.0, f)
+    }
+}
+
 // SAFETY: No internal mutability
 unsafe impl Send for TopologyBuilder {}
 
@@ -1017,15 +1024,19 @@ pub(crate) mod tests {
     use pretty_assertions::{assert_eq, assert_ne};
     use quickcheck::TestResult;
     use quickcheck_macros::quickcheck;
-    use static_assertions::assert_impl_all;
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
     use std::{
         error::Error,
-        fmt::{Binary, Debug, LowerHex, Octal, UpperHex},
-        hash::Hash,
-        ops::{
-            BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Sub, SubAssign,
+        fmt::{
+            self, Binary, Debug, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
         },
-        panic::{RefUnwindSafe, UnwindSafe},
+        hash::Hash,
+        io::{self, Read},
+        ops::{
+            BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Deref, Not, Sub,
+            SubAssign,
+        },
+        panic::UnwindSafe,
     };
     use sysinfo::PidExt;
     use tempfile::NamedTempFile;
@@ -1034,33 +1045,63 @@ pub(crate) mod tests {
     // traits, in the interest of detecting future semver-breaking changes
     assert_impl_all!(BuildFlags:
         Binary, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign,
-        Clone, Copy, Debug, Default, Eq, Extend<BuildFlags>, Flags,
+        Copy, Debug, Default, Extend<BuildFlags>, Flags,
         FromIterator<BuildFlags>, Hash, IntoIterator<Item=BuildFlags>,
-        LowerHex, Not, Octal, RefUnwindSafe, Send, Sized, Sub, SubAssign, Sync,
-        UpperHex, Unpin, UnwindSafe
+        LowerHex, Not, Octal, Sized, Sub, SubAssign, Sync, UpperHex, Unpin,
+        UnwindSafe
+    );
+    assert_not_impl_any!(BuildFlags:
+        Display, Drop, PartialOrd, Pointer, LowerExp, Read, UpperExp,
+        fmt::Write, io::Write
     );
     assert_impl_all!(FromPIDError:
-        Clone, Copy, Debug, Default, Error, Eq, From<ProcessId>, Hash,
-        RefUnwindSafe, Send, Sized, Sync, Unpin, UnwindSafe
+        Copy, Default, Error, From<ProcessId>, Hash, Sized, Sync, Unpin,
+        UnwindSafe
+    );
+    assert_not_impl_any!(FromPIDError:
+        Binary, Deref, Drop, IntoIterator,
+        LowerExp, LowerHex, Octal, PartialOrd, Pointer, Read,
+        UpperExp, UpperHex, fmt::Write, io::Write
     );
     assert_impl_all!(StringInputError:
-        Clone, Copy, Debug, Error, Eq, From<NulError>, Hash, RefUnwindSafe,
-        Send, Sized, Sync, Unpin, UnwindSafe
+        Copy, Error, From<NulError>, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(StringInputError:
+        Binary, Default, Deref, Drop, IntoIterator,
+        LowerExp, LowerHex, Octal, PartialOrd, Pointer, Read,
+        UpperExp, UpperHex, fmt::Write, io::Write
     );
     assert_impl_all!(TopologyBuilder:
-        Debug, Default, RefUnwindSafe, Send, Sized, Sync, Unpin, UnwindSafe
+        Debug, Default, Drop, Pointer, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(TopologyBuilder:
+        Binary, Clone, Deref, Display, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialEq, Read, ToOwned, UpperExp, UpperHex, fmt::Write, io::Write
     );
     assert_impl_all!(TypeFilter:
-        Clone, Copy, Debug, Eq, Hash, Into<hwloc_type_filter_e>, RefUnwindSafe,
-        Send, Sized, Sync, TryFrom<hwloc_type_filter_e>, Unpin, UnwindSafe
+        Copy, Debug, Hash, Into<hwloc_type_filter_e>, Sized, Sync,
+        TryFrom<hwloc_type_filter_e>, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(TypeFilter:
+        Binary, Default, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex,
+        Octal, PartialOrd, Pointer, Read, UpperExp, UpperHex, fmt::Write,
+        io::Write
     );
     assert_impl_all!(TypeFilterError:
-        Clone, Copy, Debug, Error, Eq, Hash, RefUnwindSafe, Send, Sized, Sync,
-        Unpin, UnwindSafe
+        Copy, Error, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(TypeFilterError:
+        Binary, Default, Deref, Drop, IntoIterator,
+        LowerExp, LowerHex, Octal, PartialOrd, Pointer, Read,
+        UpperExp, UpperHex, fmt::Write, io::Write
     );
     assert_impl_all!(FileInputError:
-        Clone, Debug, Error, Eq, From<PathError>, Hash, RefUnwindSafe,
-        Send, Sized, Sync, Unpin, UnwindSafe
+        Clone, Error, From<PathError>, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(FileInputError:
+        Binary, Copy, Default, Deref, Drop, IntoIterator,
+        LowerExp, LowerHex, Octal, PartialOrd, Pointer, Read,
+        UpperExp, UpperHex, fmt::Write, io::Write
     );
 
     // NOTE: While this doesn't match the documentation of hwloc v2.9 at the

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -1224,7 +1224,7 @@ mod tests {
     fn clone() {
         let topology = Topology::test_instance();
         let clone = topology.clone();
-        assert_ne!(format!("{topology:p}"), format!("{clone:p}"));
+        assert_ne!(format!("{:p}", *topology), format!("{clone:p}"));
         builder::tests::check_topology(
             topology,
             DataSource::ThisSystem,

--- a/src/topology/support.rs
+++ b/src/topology/support.rs
@@ -423,7 +423,59 @@ mod tests {
     use crate::topology::Topology;
     #[allow(unused)]
     use pretty_assertions::{assert_eq, assert_ne};
-    use std::{collections::hash_map::DefaultHasher, hash::Hasher, ptr};
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
+    use std::{
+        collections::hash_map::DefaultHasher,
+        fmt::{
+            self, Binary, Debug, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
+        },
+        hash::{Hash, Hasher},
+        io::{self, Read},
+        ops::Deref,
+        panic::UnwindSafe,
+        ptr,
+    };
+
+    // Check that public types in this module keep implementing all expected
+    // traits, in the interest of detecting future semver-breaking changes
+    assert_impl_all!(FeatureSupport:
+        Debug, Default, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(FeatureSupport:
+        Binary, Clone, Deref, Display, Drop, IntoIterator, LowerExp, LowerHex,
+        Octal, PartialOrd, Pointer, Read, ToOwned, UpperExp, UpperHex,
+        fmt::Write, io::Write
+    );
+    assert_impl_all!(CpuBindingSupport:
+        Copy, Default, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(CpuBindingSupport:
+        Binary, Deref, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialOrd, Pointer, Read, UpperExp, UpperHex, fmt::Write, io::Write
+    );
+    assert_impl_all!(DiscoverySupport:
+        Copy, Default, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(DiscoverySupport:
+        Binary, Deref, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialOrd, Pointer, Read, UpperExp, UpperHex, fmt::Write, io::Write
+    );
+    assert_impl_all!(MemoryBindingSupport:
+        Copy, Default, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    assert_not_impl_any!(MemoryBindingSupport:
+        Binary, Deref, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialOrd, Pointer, Read, UpperExp, UpperHex, fmt::Write, io::Write
+    );
+    #[cfg(feature = "hwloc-2_3_0")]
+    assert_impl_all!(MiscSupport:
+        Copy, Default, Hash, Sized, Sync, Unpin, UnwindSafe
+    );
+    #[cfg(feature = "hwloc-2_3_0")]
+    assert_not_impl_any!(MiscSupport:
+        Binary, Deref, Drop, IntoIterator, LowerExp, LowerHex, Octal,
+        PartialOrd, Pointer, Read, UpperExp, UpperHex, fmt::Write, io::Write
+    );
 
     fn expect_support(
         discovery: hwloc_topology_discovery_support,


### PR DESCRIPTION
It's important to also check (to some degree) which traits we're not implementing, as adding implementations and removing them later on would break semver.