### PR TITLE
Use into for most decaying conversions

### DIFF
--- a/src/object/depth.rs
+++ b/src/object/depth.rs
@@ -118,7 +118,7 @@ impl Depth {
     }
 
     /// Convert back to the hwloc depth format
-    pub(crate) fn to_raw(self) -> hwloc_get_type_depth_e {
+    pub(crate) fn into_raw(self) -> hwloc_get_type_depth_e {
         match self {
             Self::Normal(value) => value.into_c_int(),
             Self::NUMANode => HWLOC_TYPE_DEPTH_NUMANODE,
@@ -336,13 +336,13 @@ mod tests {
             assert_eq!(NormalDepth::try_from(depth), Ok(normal));
             assert_eq!(usize::try_from(depth).unwrap(), normal);
             assert_eq!(depth.assume_normal(), normal);
-            assert!(depth.to_raw() >= 0);
+            assert!(depth.into_raw() >= 0);
         } else {
             assert_eq!(depth.to_string(), format!("<{depth:?}>"));
             NormalDepth::try_from(depth).unwrap_err();
             usize::try_from(depth).unwrap_err();
             std::panic::catch_unwind(|| depth.assume_normal()).unwrap_err();
-            assert!(depth.to_raw() <= HWLOC_TYPE_DEPTH_NUMANODE);
+            assert!(depth.into_raw() <= HWLOC_TYPE_DEPTH_NUMANODE);
         }
     }
 

--- a/src/object/distance.rs
+++ b/src/object/distance.rs
@@ -128,7 +128,7 @@ impl Topology {
                     |topology, nr, distances, kind, flags| {
                         hwlocality_sys::hwloc_distances_get_by_depth(
                             topology,
-                            depth.to_raw(),
+                            depth.into_raw(),
                             nr,
                             distances,
                             kind,
@@ -709,7 +709,7 @@ impl TopologyEditor<'_> {
             errors::call_hwloc_int_normal("hwloc_distances_remove_by_depth", || unsafe {
                 hwlocality_sys::hwloc_distances_remove_by_depth(
                     self_.topology_mut_ptr(),
-                    depth.to_raw(),
+                    depth.into_raw(),
                 )
             })
             .map(std::mem::drop)

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -422,7 +422,7 @@ impl Topology {
             //           version of hwloc, and build.rs checks that the active
             //           version of hwloc is not older than that, so into() may only
             //           generate valid hwloc_get_depth_type_e values for current hwloc
-            match unsafe { hwlocality_sys::hwloc_get_depth_type(self_.as_ptr(), depth.to_raw()) }
+            match unsafe { hwlocality_sys::hwloc_get_depth_type(self_.as_ptr(), depth.into_raw()) }
                 .try_into()
             {
                 Ok(depth) => Some(depth),
@@ -479,7 +479,7 @@ impl Topology {
         //           version of hwloc is not older than that, so into() may only
         //           generate valid hwloc_get_depth_type_e values for current hwloc
         int::expect_usize(unsafe {
-            hwlocality_sys::hwloc_get_nbobjs_by_depth(self.as_ptr(), depth.to_raw())
+            hwlocality_sys::hwloc_get_nbobjs_by_depth(self.as_ptr(), depth.into_raw())
         })
     }
 
@@ -531,7 +531,7 @@ impl Topology {
         ) -> impl DoubleEndedIterator<Item = &TopologyObject> + Clone + ExactSizeIterator + FusedIterator
         {
             let size = self_.num_objects_at_depth(depth);
-            let depth = depth.to_raw();
+            let depth = depth.into_raw();
             (0..size).map(move |idx| {
                 let idx = c_uint::try_from(idx).expect("Can't happen, size comes from hwloc");
                 let ptr =

--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -447,7 +447,7 @@ impl ObjectType {
     /// Convert to the internal representation used by hwloc
     ///
     /// Used to avoid Into/From type inference ambiguities.
-    fn to_raw(self) -> hwloc_obj_type_t {
+    fn into_raw(self) -> hwloc_obj_type_t {
         hwloc_obj_type_t::from(self)
     }
 
@@ -468,9 +468,9 @@ impl ObjectType {
         // SAFETY: By construction, ObjectType only exposes values that map into
         //         hwloc_obj_type_t values understood by the configured version
         //         of hwloc, and build.rs checks that the active version of
-        //         hwloc is not older than that, so to_raw may only generate
+        //         hwloc is not older than that, so into_raw may only generate
         //         valid hwloc_obj_type_t values for current hwloc
-        errors::call_hwloc_bool(api, || unsafe { pred(self.to_raw()) })
+        errors::call_hwloc_bool(api, || unsafe { pred(self.into_raw()) })
             .expect("Object type queries should not fail")
     }
 }
@@ -486,12 +486,13 @@ impl quickcheck::Arbitrary for ObjectType {
 //
 impl PartialOrd for ObjectType {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        // SAFETY: By construction, ObjectType only exposes values that map into
-        //         hwloc_obj_type_t values understood by the configured version
-        //         of hwloc, and build.rs checks that the active version of
-        //         hwloc is not older than that, so to_raw may only generate
-        //         valid hwloc_obj_type_t values for current hwloc
-        let result = unsafe { hwlocality_sys::hwloc_compare_types(self.to_raw(), other.to_raw()) };
+        let result =
+            // SAFETY: By construction, ObjectType only exposes values that map
+            //         into hwloc_obj_type_t values understood by the configured
+            //         version of hwloc, and build.rs checks that the active
+            //         version of hwloc is not older than that, so into_raw may
+            //         only generate valid hwloc_obj_type_t values
+            unsafe { hwlocality_sys::hwloc_compare_types(self.into_raw(), other.into_raw()) };
         match result {
             HWLOC_TYPE_UNORDERED => None,
             c if c > 0 => Some(Ordering::Greater),


### PR DESCRIPTION
Per Rust API guidelines, conversions that decrease the level of abstraction should usually have a name that starts with into.