### PR TITLE
Update vendoring docs, clarify build deps, prepare some tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,15 +124,13 @@ jobs:
       - name: Build docs
         run: cargo doc ${{ env.JOB_FLAGS }}
 
-      # FIXME: Broken by v0.3.0, will bring it back after release
-      #
-      # - name: Check semver compliance
-      #   uses: obi1kenobi/cargo-semver-checks-action@v2
-      #   with:
-      #     package: hwlocality-sys # TODO: Extend once hwlocality is released
-      #     feature-group: default-features
-      #     features: ${{ matrix.features }}
-      #     rust-toolchain: manual
+      - name: Check semver compliance
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: hwlocality-sys # TODO: Extend once hwlocality is released
+          feature-group: default-features
+          features: ${{ matrix.features }}
+          rust-toolchain: manual
 
 
   # Run the tests and examples on all supported OSes and Rust versions (main CI)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,13 +124,15 @@ jobs:
       - name: Build docs
         run: cargo doc ${{ env.JOB_FLAGS }}
 
-      - name: Check semver compliance
-        uses: obi1kenobi/cargo-semver-checks-action@v2
-        with:
-          package: hwlocality-sys # TODO: Extend once hwlocality is released
-          feature-group: default-features
-          features: ${{ matrix.features }}
-          rust-toolchain: manual
+      # FIXME: Broken by v0.3.0, will bring it back after release
+      #
+      # - name: Check semver compliance
+      #   uses: obi1kenobi/cargo-semver-checks-action@v2
+      #   with:
+      #     package: hwlocality-sys # TODO: Extend once hwlocality is released
+      #     feature-group: default-features
+      #     features: ${{ matrix.features }}
+      #     rust-toolchain: manual
 
 
   # Run the tests and examples on all supported OSes and Rust versions (main CI)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           - 'hwloc-2_4_0'
           - 'hwloc-2_5_0'
           - 'hwloc-2_8_0'
-          - 'hwloc-latest,bundled'
+          - 'hwloc-latest,vendored'
           - 'hwloc-latest,proptest'
 
     env:
@@ -116,7 +116,7 @@ jobs:
         with:
           hwloc-version: ${{ env.HWLOC_VERSION }}
           hwloc-version-short: ${{ env.HWLOC_VERSION_SHORT }}
-        if: contains(matrix.features, 'bundled') == false
+        if: contains(matrix.features, 'vendored') == false
 
       - name: Check clippy lints
         run: cargo clippy ${{ env.JOB_FLAGS }} --all-targets -- -D warnings
@@ -171,7 +171,7 @@ jobs:
           - 'hwloc-2_4_0'
           - 'hwloc-2_5_0'
           - 'hwloc-2_8_0'
-          - 'hwloc-latest,bundled'
+          - 'hwloc-latest,vendored'
           - 'hwloc-latest,proptest'
 
     env:
@@ -191,15 +191,15 @@ jobs:
         with:
           hwloc-version: ${{ env.HWLOC_VERSION }}
           hwloc-version-short: ${{ env.HWLOC_VERSION_SHORT }}
-        if: contains(matrix.features, 'bundled') == false
+        if: contains(matrix.features, 'vendored') == false
 
       - name: Set up hwloc build dependencies (macOS)
         run: brew install automake
-        if: contains(matrix.features, 'bundled') && startsWith(matrix.os, 'macos')
+        if: contains(matrix.features, 'vendored') && startsWith(matrix.os, 'macos')
 
       - name: Collect system information
         uses: ./.github/actions/system-information
-        if: contains(matrix.features, 'bundled') == false
+        if: contains(matrix.features, 'vendored') == false
 
       - name: Run tests
         run: cargo test --workspace ${{ env.FEATURES_FLAG }}
@@ -428,7 +428,7 @@ jobs:
           - 'hwloc-2_4_0'
           - 'hwloc-2_5_0'
           - 'hwloc-2_8_0'
-          - 'hwloc-latest,bundled'
+          - 'hwloc-latest,vendored'
           - 'hwloc-latest,proptest'
 
     env:
@@ -448,15 +448,15 @@ jobs:
         with:
           hwloc-version: ${{ env.HWLOC_VERSION }}
           hwloc-version-short: ${{ env.HWLOC_VERSION_SHORT }}
-        if: contains(matrix.features, 'bundled') == false
+        if: contains(matrix.features, 'vendored') == false
 
       - name: Set up hwloc build dependencies (macOS)
         run: brew install automake
-        if: contains(matrix.features, 'bundled') && startsWith(matrix.os, 'macos')
+        if: contains(matrix.features, 'vendored') && startsWith(matrix.os, 'macos')
 
       - name: Collect system information
         uses: ./.github/actions/system-information
-        if: contains(matrix.features, 'bundled') == false
+        if: contains(matrix.features, 'vendored') == false
 
       - name: Install cargo-examples
         uses: baptiste0928/cargo-install@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ derive_more = { version = "0.99", default-features = false, features = ["as_mut"
 errno = "0.3"
 
 # Part of this project (raw FFI binding)
-hwlocality-sys = "0.3.0"
+hwlocality-sys = { path = "./hwlocality-sys" }
 
 # Used for malloc, free, OS typedefs, and example thread queries
 libc.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ overflow-checks = false
 
 [package]
 name = "hwlocality"
-version = "1.0.0"
+version = "1.0.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ derive_more = { version = "0.99", default-features = false, features = ["as_mut"
 errno = "0.3"
 
 # Part of this project (raw FFI binding)
-hwlocality-sys = { path = "./hwlocality-sys" }
+hwlocality-sys = "0.3.0"
 
 # Used for malloc, free, OS typedefs, and example thread queries
 libc.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ hwloc-2_8_0 = ["hwlocality-sys/hwloc-2_8_0", "hwloc-2_5_0"]
 
 # Automatically fetch and build the latest compatible hwloc version from github.
 # Otherwise, the system installation of hwloc will be used.
-bundled = ["hwlocality-sys/bundled"]
+vendored = ["hwlocality-sys/vendored"]
 
 # Implement required infrastructure for property-based testing
 proptest = ["dep:enum-iterator", "dep:proptest"]

--- a/README.md
+++ b/README.md
@@ -38,8 +38,20 @@ union fields are valid when nobody tells you they will always be.
 
 ## Prerequisites
 
-You will need a system with hwloc >=2.0.0 and associated development packages
-installed.
+`hwlocality` is compatible with `libhwloc` v2.0 and later. You can install a
+suitable version of `libhwloc` in two different ways:
+
+1. If your package manager of choice provides a reasonably recent `libhwloc`
+   package, then you can install it along with the associated development
+   package (typically called `libhwloc-dev` or `libhwloc-devel`). This is the
+   recommended way to do things because it will greatly speed up your
+   `hwlocality` (re)builds and allow you to easily keep `libhwloc` up to date
+   along with the rest of your development environment.
+2. If you cannot use the above method for any reason, then `hwlocality` can
+   alternatively download and build its own copy of `libhwloc`. To use such an
+   internal build, please enable the `bundled` Cargo feature. In addition to a
+   working C build environment, you will need to install `autotools` on Unices
+   and `cmake` on Windows.
 
 By default, compatibility with all hwloc 2.x versions is aimed for, which means
 features from newer versions in the 2.x series (or, in the near future,
@@ -51,13 +63,6 @@ hwloc 2.x releases, by enabling the cargo feature that matches the lowest hwloc
 release you need to be compatible with. See [the `[features]` section of this
 crate's Cargo.toml](https://github.com/hadrieng2/hwlocality/tree/master/Cargo.toml#L15)
 for more information.
-
-Beware that some Linux distributions provide very old hwloc versions. You may
-have to install it from [source code](https://www.open-mpi.org/projects/hwloc/).
-
-If you enable the `bundled` Cargo feature, we will attempt to build a recent
-hwloc internally. In addition to a valid C build environment, this requires
-autotools on Unices and CMake on Windows.
 
 ## Usage
 
@@ -159,9 +164,9 @@ be redirected to the suggested replacement in the Rust API.
 The main exceptions to this rule are notions that are not needed in Rust due to
 ergonomics improvements permitted by the Rust type system. For example...
 
-- C-style manual destructors are replaced by Drop impls
+- C-style manual destructors are replaced by `Drop` impls
 - Type argument clarification flags like `HWLOC_MEMBIND_BYNODESET` are replaced
-  by generics that do the right thing. 
+  by generics that do the right thing automatically. 
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ suitable version of `libhwloc` in two different ways:
    along with the rest of your development environment.
 2. If you cannot use the above method for any reason, then `hwlocality` can
    alternatively download and build its own copy of `libhwloc`. To use such an
-   internal build, please enable the `bundled` Cargo feature. In addition to a
-   working C build environment, you will need to install `autotools` on Unices
-   and `cmake` on Windows.
+   internal build, please enable the `vendored` Cargo feature. In addition to a
+   working C build environment, you will need `automake` and `libtool` on
+   Unices, and `cmake` on Windows.
+
+Unless you are using a vendored version of hwloc of Windows, you will also need
+to install `pkg-config` or one of its clones (`pkgconf`, `pkgconfiglite`...), as
+it is used to find `libhwloc` and set up `hwlocality` to link against it.
 
 By default, compatibility with all hwloc 2.x versions is aimed for, which means
 features from newer versions in the 2.x series (or, in the near future,

--- a/hwlocality-sys/Cargo.toml
+++ b/hwlocality-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hwlocality-sys"
-version = "0.2.1"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/hwlocality-sys/Cargo.toml
+++ b/hwlocality-sys/Cargo.toml
@@ -21,7 +21,7 @@ hwloc-2_3_0 = ["hwloc-2_2_0"]
 hwloc-2_4_0 = ["hwloc-2_3_0"]
 hwloc-2_5_0 = ["hwloc-2_4_0"]
 hwloc-2_8_0 = ["hwloc-2_5_0"]
-bundled = ["dep:autotools", "dep:cmake"]
+vendored = ["dep:autotools", "dep:cmake"]
 # This feature does nothing in -sys and is only here for CI convenience
 proptest = []
 
@@ -34,13 +34,13 @@ windows-sys.workspace = true
 libc.workspace = true
 
 [build-dependencies]
-# Used for bundled builds on OSes other than Windows
+# Used for vendored builds on OSes other than Windows
 autotools = { version = "0.2", optional = true }
 
-# Used for bundled builds on Windows
+# Used for vendored builds on Windows
 cmake = { version = "0.1.50", optional = true }
 
-# Used to locate hwloc except in cmake bundled builds
+# Used to locate hwloc except in cmake vendored builds
 pkg-config = "0.3.8"
 
 [dev-dependencies]

--- a/hwlocality-sys/Cargo.toml
+++ b/hwlocality-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hwlocality-sys"
-version = "0.2.0"
+version = "0.2.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/hwlocality-sys/README.md
+++ b/hwlocality-sys/README.md
@@ -11,9 +11,14 @@ This crate contains the low-level unsafe Rust -> C FFI bindings to
 [hwloc](http://www.open-mpi.org/projects/hwloc), that are used to implement the
 safe [hwlocality](https://github.com/HadrienG2/hwlocality) bindings.
 
-Like any C API, these low-level bindings are highly unsafe to use, and it is
-advised that you use the safe bindings instead whenever possible.
+Depending on your needs, you can either link to a `libhwloc` that is
+pre-installed on your computer or have `hwlocality` build its own copy
+`libhwloc` internally. Please read [the "Prerequisites" section of the
+hwlocality README](https://github.com/HadrienG2/hwlocality#prerequisites) for
+more information about these two options.
 
-If you encounter any issue with the safe bindings that prevents you from using
-them and forces you to use the unsafe C API directly, please report it to me and
-I'll do my best to get it fixed.
+Like any C API, the `hwlocality-sys` low-level bindings are highly unsafe to
+use, and it is advised that you use the safe `hwlocality` bindings instead
+whenever possible. If you encounter any issue with the safe bindings that
+prevents you from using them and forces you to use the unsafe C API directly,
+please report them in the issue tracker so we get them fixed.

--- a/hwlocality-sys/build.rs
+++ b/hwlocality-sys/build.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "bundled")]
+#[cfg(feature = "vendored")]
 use std::{
     env,
     path::{Path, PathBuf},
@@ -34,16 +34,16 @@ fn setup_hwloc() {
     };
 
     // If asked to build hwloc ourselves, do so
-    #[cfg(feature = "bundled")]
-    setup_bundled_hwloc(required_version);
+    #[cfg(feature = "vendored")]
+    setup_vendored_hwloc(required_version);
 
     // If asked to use system hwloc, configure it using pkg-config
-    #[cfg(not(feature = "bundled"))]
+    #[cfg(not(feature = "vendored"))]
     find_hwloc(Some(required_version));
 }
 
 /// Use pkg-config to locate and use a certain hwloc release
-#[cfg(not(all(feature = "bundled", windows)))]
+#[cfg(not(all(feature = "vendored", windows)))]
 fn find_hwloc(required_version: Option<&str>) -> pkg_config::Library {
     // Initialize pkg-config
     let mut config = pkg_config::Config::new();
@@ -85,8 +85,8 @@ fn find_hwloc(required_version: Option<&str>) -> pkg_config::Library {
 }
 
 /// Install hwloc ourselves
-#[cfg(feature = "bundled")]
-fn setup_bundled_hwloc(required_version: &str) {
+#[cfg(feature = "vendored")]
+fn setup_vendored_hwloc(required_version: &str) {
     // Determine which version to fetch and where to fetch it
     let source_version = match required_version
         .split('.')
@@ -112,7 +112,7 @@ fn setup_bundled_hwloc(required_version: &str) {
 }
 
 /// Fetch hwloc from a git release branch, return repo path
-#[cfg(feature = "bundled")]
+#[cfg(feature = "vendored")]
 fn fetch_hwloc(parent_path: impl AsRef<Path>, version: &str) -> PathBuf {
     // Determine location of the git repo and its parent directory
     let parent_path = parent_path.as_ref();
@@ -152,7 +152,7 @@ fn fetch_hwloc(parent_path: impl AsRef<Path>, version: &str) -> PathBuf {
 }
 
 /// Compile hwloc using cmake, return local installation path
-#[cfg(all(feature = "bundled", windows))]
+#[cfg(all(feature = "vendored", windows))]
 fn install_hwloc_cmake(source_path: impl AsRef<Path>) {
     // Locate CMake support files, make sure they are present
     // (should be the case on any hwloc release since 2.8)
@@ -193,7 +193,7 @@ fn install_hwloc_cmake(source_path: impl AsRef<Path>) {
 }
 
 /// Compile hwloc using autotools, return local installation path
-#[cfg(all(feature = "bundled", not(windows)))]
+#[cfg(all(feature = "vendored", not(windows)))]
 fn install_hwloc_autotools(source_path: impl AsRef<Path>) {
     // Build using autotools
     let mut config = autotools::Config::new(source_path);

--- a/hwlocality-sys/src/lib.rs
+++ b/hwlocality-sys/src/lib.rs
@@ -3323,10 +3323,10 @@ macro_rules! extern_c_block {
     };
 }
 
-#[cfg(all(not(feature = "bundled"), target_os = "windows"))]
+#[cfg(all(not(feature = "vendored"), target_os = "windows"))]
 extern_c_block!("libhwloc");
 
-#[cfg(all(feature = "bundled", target_os = "windows"))]
+#[cfg(all(feature = "vendored", target_os = "windows"))]
 extern_c_block!("hwloc");
 
 #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
Following discussion with @uglyoldbob and @nazar-pc in #25 and #81, clarify how the bundled feature works in the various READMEs and prepare to tag a first alpha release of the main `hwlocality` library.

I'd be happy to also rename the `bundled` feature to some other name that contains the "vendor" keyword, like `vendor-hwloc`, if both of you agree that this is a better name. Feel free to tell me what you think!

In absence of answers and further suggestions, I'll merge this and create the tags at some point during the first week of January.

Fixes #25.
Fixes #81.
Fixes #84.