### PR TITLE
Build static library on macOS

### DIFF
--- a/hwlocality-sys/Cargo.toml
+++ b/hwlocality-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hwlocality-sys"
-version = "0.3.0"
+version = "0.3.1"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/hwlocality-sys/build.rs
+++ b/hwlocality-sys/build.rs
@@ -198,14 +198,13 @@ fn install_hwloc_autotools(source_path: impl AsRef<Path>) {
     // Build using autotools
     let mut config = autotools::Config::new(source_path);
     if cfg!(target_os = "macos") {
-        // macOS really doesn't like static builds...
-        config.disable_static();
-        config.enable_shared();
-    } else {
-        // ...but they make life easier elsewhere
-        config.enable_static();
-        config.disable_shared();
+        // macOS need some extra stuff to be linked for all symbols to be found
+        config.ldflag("-F/System/Library/Frameworks -framework CoreFoundation");
+        // And libxml2 needs to be linked in explicitly for some inexplicable reason
+        println!("cargo:rustc-link-lib=xml2");
     }
+    config.enable_static();
+    config.disable_shared();
     let install_path = config.fast_build(true).reconf("-ivf").build();
 
     // Compute the associated PKG_CONFIG_PATH


### PR DESCRIPTION
Linking to framework was easy (even though I'm not sure if that is recommended way, I know there is also a way to specify attribute like `#[link(name = "CoreFoundation", kind = "framework")]`.

For libxml2 something is messed up. I tried installing and using it via brew, but that didn't seem to work. No idea if libxml2 is guaranteed to exist on every macOS installation, but it definitely works at least on some systems.

My understanding is that either autotools integration is incomplete that requires these additional steps or C libraries are a pain to deal with in general, also both can be true at the same time.

Either way, it seems to work and pass CI.

Fixes https://github.com/HadrienG2/hwlocality/issues/31