### PR TITLE
Use official hwloc source tarballs for vendored builds, with checksums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,11 @@ hwloc-2_8_0 = ["hwlocality-sys/hwloc-2_8_0", "hwloc-2_5_0"]
 # - Make it enable features associated with all previous versions.
 # - Change hwloc-latest to point to that feature.
 # - Update hwlocality-sys' Cargo.toml similarly
-# - Update hwlocality-sys' build.rs to up the build requirements.
+# - Update hwlocality-sys' build.rs to...
+#   * Record the new feature's hwloc version requirements in `setup_hwloc()`
+#   * Use a newer official tarball, with appropriate checksum (can be computed
+#     using `curl <tar.gz url> | sha3-256sum`), in `setup_vendored_hwloc()`
+#   * If this is a new major version, add support for it in `find_hwloc()`
 # - Make the binding honor the API/ABI changes with the right cfg()s.
 # - Bump the crate's minor release number unless previous version was unreleased.
 # - Add this feature to the CI's linter matrix and both test matrices.

--- a/hwlocality-sys/Cargo.toml
+++ b/hwlocality-sys/Cargo.toml
@@ -21,7 +21,7 @@ hwloc-2_3_0 = ["hwloc-2_2_0"]
 hwloc-2_4_0 = ["hwloc-2_3_0"]
 hwloc-2_5_0 = ["hwloc-2_4_0"]
 hwloc-2_8_0 = ["hwloc-2_5_0"]
-vendored = ["dep:autotools", "dep:cmake"]
+vendored = ["dep:autotools", "dep:cmake", "dep:flate2", "dep:hex-literal", "dep:reqwest", "dep:sha3", "dep:tar"]
 # This feature does nothing in -sys and is only here for CI convenience
 proptest = []
 
@@ -34,14 +34,21 @@ windows-sys.workspace = true
 libc.workspace = true
 
 [build-dependencies]
-# Used for vendored builds on OSes other than Windows
-autotools = { version = "0.2", optional = true }
-
-# Used for vendored builds on Windows
-cmake = { version = "0.1.50", optional = true }
-
 # Used to locate hwloc except in cmake vendored builds
 pkg-config = "0.3.8"
+
+# Used for vendored builds on all OSes
+flate2 = { version = "1.0", optional = true }
+hex-literal = { version = "0.4", optional = true }
+reqwest = { version = "0.11", features = ["blocking"], optional = true }
+sha3 = { version = "0.10.8", optional = true }
+tar = { version = "0.4", optional = true }
+
+# Used for vendored builds targeting OSes other than Windows
+autotools = { version = "0.2", optional = true }
+
+# Used for vendored builds targeting Windows
+cmake = { version = "0.1.50", optional = true }
 
 [dev-dependencies]
 # Used to check trait implementations

--- a/hwlocality-sys/build.rs
+++ b/hwlocality-sys/build.rs
@@ -23,7 +23,7 @@ fn main() {
 
 /// Configure the hwloc dependency
 fn setup_hwloc() {
-    // Determine the minimal supported hwloc version with current featurees
+    // Determine the minimal supported hwloc version with current features
     let required_version = if cfg!(feature = "hwloc-2_8_0") {
         "2.8.0"
     } else if cfg!(feature = "hwloc-2_5_0") {
@@ -96,7 +96,7 @@ fn find_hwloc(required_version: Option<&str>) -> pkg_config::Library {
 #[cfg(feature = "vendored")]
 fn setup_vendored_hwloc(required_version: &str) {
     // Determine which version to fetch and where to fetch it
-    let (source_version, source_digest) = match required_version
+    let (source_version, sha3_digest) = match required_version
         .split('.')
         .next()
         .expect("No major version in required_version")
@@ -110,7 +110,7 @@ fn setup_vendored_hwloc(required_version: &str) {
     let out_path = env::var("OUT_DIR").expect("No output directory given");
 
     // Fetch latest supported hwloc from git
-    let source_path = fetch_hwloc(out_path, source_version, source_digest);
+    let source_path = fetch_hwloc(out_path, source_version, sha3_digest);
 
     // On Windows, we build using CMake because the autotools build
     // procedure does not work with MSVC, which is often needed on this OS
@@ -124,7 +124,7 @@ fn setup_vendored_hwloc(required_version: &str) {
 
 /// Fetch, check and extract an official hwloc tarball, return extracted path
 #[cfg(feature = "vendored")]
-fn fetch_hwloc(parent_path: impl AsRef<Path>, version: &str, digest: [u8; 32]) -> PathBuf {
+fn fetch_hwloc(parent_path: impl AsRef<Path>, version: &str, sha3_digest: [u8; 32]) -> PathBuf {
     // Predict location where tarball would be extracted
     let parent_path = parent_path.as_ref();
     let extracted_path = parent_path.join(format!("hwloc-{version}"));
@@ -156,7 +156,7 @@ fn fetch_hwloc(parent_path: impl AsRef<Path>, version: &str, digest: [u8; 32]) -
     hasher.update(&tar_gz[..]);
     assert_eq!(
         &hasher.finalize()[..],
-        digest,
+        sha3_digest,
         "downloaded hwloc source failed integrity check"
     );
 

--- a/hwlocality-sys/build.rs
+++ b/hwlocality-sys/build.rs
@@ -1,10 +1,18 @@
 use std::sync::OnceLock;
 #[cfg(feature = "vendored")]
-use std::{
-    env,
-    path::{Path, PathBuf},
-    process::Command,
-};
+mod vendored_deps {
+    pub use flate2::read::GzDecoder;
+    pub use hex_literal::hex;
+    pub use sha3::{Digest, Sha3_256};
+    pub use std::{
+        env,
+        path::{Path, PathBuf},
+        process::Command,
+    };
+    pub use tar::Archive;
+}
+#[cfg(feature = "vendored")]
+use vendored_deps::*;
 
 fn main() {
     // We don't need hwloc on docs.rs since it only builds the docs
@@ -88,18 +96,21 @@ fn find_hwloc(required_version: Option<&str>) -> pkg_config::Library {
 #[cfg(feature = "vendored")]
 fn setup_vendored_hwloc(required_version: &str) {
     // Determine which version to fetch and where to fetch it
-    let source_version = match required_version
+    let (source_version, source_digest) = match required_version
         .split('.')
         .next()
         .expect("No major version in required_version")
     {
-        "2" => "v2.x",
+        "2" => (
+            "2.10.0",
+            hex!("b3e5e208587cd366fc2975f21102c20f3b1094d3cae69f464cb1bd8b09f302aa"),
+        ),
         other => panic!("Please add support for bundling hwloc v{other}.x"),
     };
     let out_path = env::var("OUT_DIR").expect("No output directory given");
 
     // Fetch latest supported hwloc from git
-    let source_path = fetch_hwloc(out_path, source_version);
+    let source_path = fetch_hwloc(out_path, source_version, source_digest);
 
     // On Windows, we build using CMake because the autotools build
     // procedure does not work with MSVC, which is often needed on this OS
@@ -111,44 +122,54 @@ fn setup_vendored_hwloc(required_version: &str) {
     }
 }
 
-/// Fetch hwloc from a git release branch, return repo path
+/// Fetch, check and extract an official hwloc tarball, return extracted path
 #[cfg(feature = "vendored")]
-fn fetch_hwloc(parent_path: impl AsRef<Path>, version: &str) -> PathBuf {
-    // Determine location of the git repo and its parent directory
+fn fetch_hwloc(parent_path: impl AsRef<Path>, version: &str, digest: [u8; 32]) -> PathBuf {
+    // Predict location where tarball would be extracted
     let parent_path = parent_path.as_ref();
-    let repo_path = parent_path.join("hwloc");
+    let extracted_path = parent_path.join(format!("hwloc-{version}"));
 
-    // Clone the repo if this is the first time, update it with pull otherwise
-    let output = if !repo_path.join("Makefile.am").exists() {
-        Command::new("git")
-            .args([
-                "clone",
-                "https://github.com/open-mpi/hwloc",
-                "--depth",
-                "1",
-                "--branch",
-                version,
-            ])
-            .current_dir(parent_path)
-            .output()
-            .expect("git clone for hwloc failed")
-    } else {
-        Command::new("git")
-            .args(["pull", "--ff-only", "origin", "v2.x"])
-            .current_dir(&repo_path)
-            .output()
-            .expect("git pull for hwloc failed")
-    };
+    // Reuse any existing download
+    if extracted_path.exists() {
+        eprintln!("Reusing previous hwloc v{version} download");
+        return extracted_path;
+    }
 
-    // Make sure the command returned a successful status
-    let status = output.status;
-    assert!(
-        status.success(),
-        "git clone/pull for hwloc returned failure status {status}:\n{output:?}"
+    // Determine hwloc tarball URL
+    let mut version_components = version.split('.');
+    let major = version_components.next().expect("no major hwloc version");
+    let minor = version_components.next().expect("no minor hwloc version");
+    let url = format!(
+        "https://download.open-mpi.org/release/hwloc/v{major}.{minor}/hwloc-{version}.tar.gz"
     );
 
-    // Propagate repo path
-    repo_path
+    // Download hwloc tarball
+    eprintln!("Downloading hwloc v{version} from URL {url}...");
+    let tar_gz = reqwest::blocking::get(url)
+        .expect("failed to GET hwloc source")
+        .bytes()
+        .expect("failed to parse hwloc source HTTP body");
+
+    // Verify tarball integrity
+    eprintln!("Verifying hwloc source integrity...");
+    let mut hasher = Sha3_256::new();
+    hasher.update(&tar_gz[..]);
+    assert_eq!(
+        &hasher.finalize()[..],
+        digest,
+        "downloaded hwloc source failed integrity check"
+    );
+
+    // Extract tarball
+    eprintln!("Extracting hwloc source...");
+    let tar = GzDecoder::new(&tar_gz[..]);
+    let mut archive = Archive::new(tar);
+    archive
+        .unpack(parent_path)
+        .expect("failed to extract hwloc source");
+
+    // Predict location where tarball was extracted
+    extracted_path
 }
 
 /// Compile hwloc using cmake, return local installation path

--- a/hwlocality-sys/build.rs
+++ b/hwlocality-sys/build.rs
@@ -7,7 +7,6 @@ mod vendored_deps {
     pub use std::{
         env,
         path::{Path, PathBuf},
-        process::Command,
     };
     pub use tar::Archive;
 }


### PR DESCRIPTION
Fixes #89 by replacing git branch cloning with a checksummed official hwloc tarball.

This comes at the cost of adding several heavy dependencies, and thus cold vendored builds getting much slower. But since configure scripts are slow, these builds have never been the preferred option from a performance perspective to begin with, so I guess this is a reasonable tradeoff...