### PR TITLE
Fix lints in nightly CI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,7 +455,7 @@ pub(crate) mod tests {
     thread_local! {
         /// Number of active [`SilentPanicGuard`] in the current thread. If
         /// this is greater than one, panics will be silenced.
-        static SILENCE_DEPTH: Cell<usize> = Cell::new(0);
+        static SILENCE_DEPTH: Cell<usize> = const { Cell::new(0) };
     }
     //
     impl SilentPanicGuard {

--- a/src/topology/export/xml.rs
+++ b/src/topology/export/xml.rs
@@ -318,16 +318,16 @@ impl Ord for XML<'_> {
 
 impl PartialEq for XML<'_> {
     fn eq(&self, other: &Self) -> bool {
-        self.as_str().eq(other.as_str())
+        self.as_str() == other.as_str()
     }
 }
 
 impl<T> PartialEq<T> for XML<'_>
 where
-    str: PartialEq<T>,
+    for<'a> &'a str: PartialEq<T>,
 {
     fn eq(&self, other: &T) -> bool {
-        self.as_str().eq(other)
+        self.as_str() == *other
     }
 }
 


### PR DESCRIPTION
Technically, one of the "fixes" is actually a workaround for a [clippy false positive](https://github.com/rust-lang/rust-clippy/issues/12181). But I actually like the workaround version better.

Along the way, this also fixes a trait bound bug where the "external" PartialEq impl of XML did not work because I expressed it in terms of `str`, when string comparison traits are actually implemented for `&str`.