### PR TITLE
Use a simpler HTTP client library for vendored build

### DIFF
--- a/hwlocality-sys/Cargo.toml
+++ b/hwlocality-sys/Cargo.toml
@@ -22,7 +22,7 @@ hwloc-2_4_0 = ["hwloc-2_3_0"]
 hwloc-2_5_0 = ["hwloc-2_4_0"]
 hwloc-2_8_0 = ["hwloc-2_5_0"]
 hwloc-2_10_0 = ["hwloc-2_8_0"]
-vendored = ["dep:autotools", "dep:cmake", "dep:flate2", "dep:hex-literal", "dep:reqwest", "dep:sha3", "dep:tar"]
+vendored = ["dep:attohttpc", "dep:autotools", "dep:cmake", "dep:flate2", "dep:hex-literal", "dep:sha3", "dep:tar"]
 vendored-extra = ["vendored"]
 # This feature does nothing in -sys and is only here for CI convenience
 proptest = []
@@ -40,9 +40,9 @@ libc.workspace = true
 pkg-config = "0.3.8"
 
 # Used for vendored builds on all OSes
+attohttpc = { version = "0.27", default-features = false, features = ["compress", "tls-rustls-webpki-roots"], optional = true }
 flate2 = { version = "1.0", optional = true }
 hex-literal = { version = "0.4", optional = true }
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls"], optional = true }
 sha3 = { version = "0.10.8", optional = true }
 tar = { version = "0.4", optional = true }
 

--- a/hwlocality-sys/build.rs
+++ b/hwlocality-sys/build.rs
@@ -146,7 +146,8 @@ fn fetch_hwloc(parent_path: impl AsRef<Path>, version: &str, sha3_digest: [u8; 3
 
     // Download hwloc tarball
     eprintln!("Downloading hwloc v{version} from URL {url}...");
-    let tar_gz = reqwest::blocking::get(url)
+    let tar_gz = attohttpc::get(url)
+        .send()
         .expect("failed to GET hwloc source")
         .bytes()
         .expect("failed to parse hwloc source HTTP body");


### PR DESCRIPTION
Vendored build currently use reqwest for hwloc tarball downloads, which comes with the entire circus of async dependencies. By using a simpler HTTP client, the dependency count can be cut in half and the vendored build time can be reduced a little bit (-10% on my machine).