### PR TITLE
Turns out doc(cfg()) is not the valid way to hide cfg from docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ overflow-checks = false
 
 [package]
 name = "hwlocality"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,7 @@ pub type ThreadId = hwloc_thread_t;
 
 /// Get the current thread's identifier through the libc or windows API
 #[cfg(not(target_os = "windows"))]
-#[cfg_attr(docsrs, doc(cfg()))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn current_thread_id() -> ThreadId {
     // SAFETY: Should be always safe to call
     let id = unsafe { libc::pthread_self() };
@@ -279,7 +279,7 @@ pub fn current_thread_id() -> ThreadId {
 //
 /// Get the current thread's identifier through the libc or windows API
 #[cfg(target_os = "windows")]
-#[cfg_attr(docsrs, doc(cfg()))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn current_thread_id() -> ThreadId {
     // SAFETY: Should be always safe to call on Windows
     unsafe { windows_sys::Win32::System::Threading::GetCurrentThread() }


### PR DESCRIPTION
Instead, according to https://github.com/rust-lang/rust/pull/89596, you need an extra all() to achieve this result.