### PR TITLE
Ignore cast_possible_truncation lint from nightly clippy

### DIFF
--- a/src/ffi/int.rs
+++ b/src/ffi/int.rs
@@ -3015,7 +3015,7 @@ macro_rules! shr_with_int {
         impl Shr<$int> for PositiveInt {
             type Output = Self;
 
-            #[allow(trivial_numeric_casts)]
+            #[allow(trivial_numeric_casts, clippy::cast_possible_truncation)]
             fn shr(self, mut rhs: $int) -> Self {
                 if cfg!(debug_assertions) {
                     // Debug mode checks if the shift is in range

--- a/src/ffi/int.rs
+++ b/src/ffi/int.rs
@@ -2923,7 +2923,7 @@ macro_rules! shl_with_int {
         impl Shl<$int> for PositiveInt {
             type Output = Self;
 
-            #[allow(trivial_numeric_casts)]
+            #[allow(trivial_numeric_casts, clippy::cast_possible_truncation)]
             fn shl(self, mut rhs: $int) -> Self {
                 if cfg!(debug_assertions) {
                     // Debug mode checks if the shift is in range


### PR DESCRIPTION
This lint fires on the cast of a constant which represents the number of bits of the "int" C type. We know that for any foreseeable time to come, this constant will fit into any integer type, even i8, so ignoring the lint is fine.