### PR TITLE
Set build mode to Release in hwlocality-sys

### DIFF
--- a/hwlocality-sys/build.rs
+++ b/hwlocality-sys/build.rs
@@ -204,6 +204,9 @@ fn install_hwloc_cmake(source_path: impl AsRef<Path>) {
     config.define("HWLOC_SKIP_LSTOPO", "1");
     config.define("HWLOC_SKIP_TOOLS", "1");
 
+    // Set the mode to Release
+    config.profile("Release");
+
     // Build hwloc
     let install_path = config.always_configure(false).build();
 


### PR DESCRIPTION
Small change on `vandored` build hwlocality for windows platform. This set the profile for the cmake on windows to `Release`. It will ensure that there is no debug logs being written to the stdout when running the library.