### PR TITLE
Don't include build script in code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+    - "hwlocality-sys/build.rs"


### PR DESCRIPTION
- Build scripts are hard to test in and of themselves.
- It is hard to extract subsets for proper unit testing.
- Practical testing is just a matter of testing several OS configurations anyway, and we already do that.