### PR TITLE
Handle unknown flags and enum variants from hwloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,26 +169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "enum-iterator"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c280b9e6b3ae19e152d8e31cf47f18389781e119d4013a2a2bb0180e5facc635"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +256,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,15 +285,14 @@ dependencies = [
  "arrayvec",
  "bitflags",
  "derive_more",
- "enum-iterator",
  "errno",
  "eyre",
  "hwlocality-sys",
  "libc",
- "num_enum",
  "proptest",
  "similar-asserts",
  "static_assertions",
+ "strum",
  "sysinfo",
  "tempfile",
  "thiserror",
@@ -420,27 +405,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
-dependencies = [
- "num_enum_derive",
- "rustversion",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -741,6 +705,28 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hwlocality"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "arrayvec",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,10 +188,7 @@ arrayvec = "0.7"
 bitflags = "2.9"
 
 # Used to simplify the implementation of newtypes
-derive_more = { version = "2.0", default-features = false, features = ["as_ref", "display", "from", "into", "into_iterator", "not"] }
-
-# Used for optional proptest feature and in topology debug output
-enum-iterator = "2.0"
+derive_more = { version = "2.0", default-features = false, features = ["as_ref", "deref", "display", "from", "into", "into_iterator", "not"] }
 
 # Used to interpret and report hwloc error codes
 errno = "0.3"
@@ -202,8 +199,8 @@ hwlocality-sys = { path = "./hwlocality-sys" }
 # Used for malloc, free, OS typedefs, and example thread queries
 libc.workspace = true
 
-# Used to interface hwloc enums
-num_enum = { version = "0.7", default-features = false }
+# Used to interface hwloc enums + for proptests and topology debug output
+strum = { version = "0.27.1", features = ["derive"] }
 
 # Used to simplify error reporting
 thiserror = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ overflow-checks = false
 
 [package]
 name = "hwlocality"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -7,6 +7,7 @@
 pub(crate) mod int;
 pub(crate) mod string;
 pub(crate) mod transparent;
+pub(crate) mod unknown;
 
 #[allow(unused)]
 #[cfg(test)]

--- a/src/ffi/unknown.rs
+++ b/src/ffi/unknown.rs
@@ -1,0 +1,42 @@
+//! Handling of unknown enum variants
+
+use derive_more::{AsRef, Binary, Deref, Display, LowerExp, LowerHex, Octal, UpperExp, UpperHex};
+
+/// Unknown enum variant from `hwloc`
+///
+/// Values of this type represent enum values received from `hwloc` that
+/// `hwlocality` was not built to handle. This can happen when `hwlocality` is
+/// built to support a certain minimal `hwloc` version, but is then linked
+/// against a newer `hwloc` version that defines new enum variants.
+///
+/// You may freely introspect the contents of these enum values, but are not
+/// allowed to generate new ones from Rust integers. Thanks to this,
+/// `hwlocality` can assume that these values are valid inputs that your `hwloc`
+/// version can accept (since it originally emitted them as the output of
+/// another query). And therefore you will be able to feed these values back to
+/// `hwloc` in most circumstances.
+///
+/// This capability to feed back unknown enum values to `hwloc` will however be
+/// restricted in circumstances where `hwloc` treats enum variants in such
+/// a way that sending it an unknown enum variant could result in a memory-,
+/// type- or thread-safety hazard.
+#[derive(
+    AsRef,
+    Binary,
+    Copy,
+    Clone,
+    Debug,
+    Deref,
+    Display,
+    Eq,
+    Hash,
+    LowerExp,
+    LowerHex,
+    Octal,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    UpperExp,
+    UpperHex,
+)]
+pub struct UnknownVariant<T>(pub(crate) T);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,9 +235,6 @@ pub mod topology;
 #[cfg(feature = "proptest")]
 pub use proptest;
 
-/// Re-export `enum_iterator` version we're built against
-pub use enum_iterator;
-
 use crate::ffi::int;
 use hwlocality_sys::hwloc_thread_t;
 #[allow(unused)]
@@ -342,7 +339,7 @@ mod sealed {
 pub(crate) use sealed::Sealed;
 
 /// Implement [`proptest::Arbitrary`] for a C-like enum that implements
-/// [`enum_iterator::Sequence`]
+/// [`strum::EnumCount`] and [`strum::EnumIter`].
 #[doc(hidden)]
 #[macro_export]
 macro_rules! impl_arbitrary_for_sequence {
@@ -354,9 +351,10 @@ macro_rules! impl_arbitrary_for_sequence {
 
             fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
                 use proptest::prelude::*;
-                let cardinality = <Self as enum_iterator::Sequence>::CARDINALITY;
+                use strum::IntoEnumIterator;
+                let cardinality = <Self as strum::EnumCount>::COUNT;
                 (0..cardinality).prop_map(|idx| {
-                    enum_iterator::all::<Self>()
+                    Self::iter()
                         .nth(idx)
                         .expect("idx is in range by definition")
                 })

--- a/src/memory/attribute.rs
+++ b/src/memory/attribute.rs
@@ -1009,7 +1009,7 @@ impl<'topology> MemoryAttribute<'topology> {
         let handle_einval =
             || unreachable!("MemoryAttribute should only hold valid attribute indices");
         match res {
-            Ok(_positive) => MemoryAttributeFlags::from_bits_truncate(flags),
+            Ok(_positive) => MemoryAttributeFlags::from_bits_retain(flags),
             Err(RawHwlocError {
                 errno: Some(Errno(EINVAL)),
                 ..

--- a/src/object/attributes/mod.rs
+++ b/src/object/attributes/mod.rs
@@ -176,6 +176,7 @@ mod tests {
                 | ObjectType::Misc => check_nonexistent()?,
                 #[cfg(feature = "hwloc-2_1_0")]
                 ObjectType::MemCache | ObjectType::Die => check_nonexistent()?,
+                ObjectType::Unknown(_) => {}
             }
         }
     }
@@ -199,6 +200,7 @@ mod tests {
                     CacheType::Instruction => {
                         prop_assert!(obj.object_type().is_cpu_instruction_cache());
                     }
+                    CacheType::Unknown(_) => {}
                 },
                 #[allow(unused)]
                 Some(ObjectAttributes::Group(attr)) => {
@@ -225,6 +227,7 @@ mod tests {
                     match attr.upstream_type() {
                         BridgeType::PCI => prop_assert!(has_pci_parent),
                         BridgeType::Host => prop_assert!(!has_pci_parent),
+                        BridgeType::Unknown(_) => {}
                     }
                 }
                 Some(ObjectAttributes::OSDevice(_attr)) => {

--- a/src/object/distance.rs
+++ b/src/object/distance.rs
@@ -921,7 +921,7 @@ impl<'topology> Distances<'topology> {
     #[doc(alias = "hwloc_distances_s::kind")]
     pub fn kind(&self) -> DistancesKind {
         // SAFETY: No invalid mutation of inner state occurs
-        let result = DistancesKind::from_bits_truncate(unsafe { self.inner().kind });
+        let result = DistancesKind::from_bits_retain(unsafe { self.inner().kind });
         assert!(
             result.is_valid(false),
             "hwloc should not emit invalid kinds"

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -132,7 +132,8 @@ impl TopologyObject {
     /// Type of object
     #[doc(alias = "hwloc_obj::type")]
     pub fn object_type(&self) -> ObjectType {
-        self.0.ty.try_into().expect("Got unexpected object type")
+        // SAFETY: Object type does come from hwloc
+        unsafe { ObjectType::from_hwloc(self.0.ty) }
     }
 
     /// Subtype string to better describe the type field
@@ -263,7 +264,8 @@ impl TopologyObject {
     /// tree, this is a special value that is unique to their type.
     #[doc(alias = "hwloc_obj::depth")]
     pub fn depth(&self) -> Depth {
-        Depth::from_raw(self.0.depth).expect("Got unexpected depth value")
+        // SAFETY: Depth value does come from hwloc
+        unsafe { Depth::from_hwloc(self.0.depth) }.expect("Got unexpected depth value")
     }
 
     /// Parent object

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -516,7 +516,7 @@ impl TopologyBuilder {
     pub fn flags(&self) -> BuildFlags {
         // SAFETY: - TopologyBuilder is trusted to contain a valid ptr (type invariant)
         //         - hwloc ops are trusted not to modify *const parameters
-        let result = BuildFlags::from_bits_truncate(unsafe {
+        let result = BuildFlags::from_bits_retain(unsafe {
             hwlocality_sys::hwloc_topology_get_flags(self.as_ptr())
         });
         assert!(result.is_valid(), "hwloc should not send out invalid flags");

--- a/src/topology/export/synthetic.rs
+++ b/src/topology/export/synthetic.rs
@@ -144,6 +144,7 @@ mod tests {
     use proptest::prelude::*;
     #[allow(unused)]
     use similar_asserts::assert_eq;
+    use strum::IntoEnumIterator;
 
     proptest! {
         #[test]
@@ -178,7 +179,7 @@ mod tests {
             //
             if !flags.contains(SyntheticExportFlags::NO_EXTENDED_TYPES) {
                 let flags_affecting_memobjs = SyntheticExportFlags::IGNORE_MEMORY | SyntheticExportFlags::V1;
-                for ty in enum_iterator::all::<ObjectType>() {
+                for ty in ObjectType::iter() {
                     if ty.is_normal()
                        || (ty.is_memory() && !flags.intersects(flags_affecting_memobjs))
                     {

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -251,7 +251,7 @@ impl Topology {
     pub fn build_flags(&self) -> BuildFlags {
         // SAFETY: - Topology is trusted to contain a valid ptr (type invariant)
         //         - hwloc ops are trusted not to modify *const parameters
-        let result = BuildFlags::from_bits_truncate(unsafe {
+        let result = BuildFlags::from_bits_retain(unsafe {
             hwlocality_sys::hwloc_topology_get_flags(self.as_ptr())
         });
         assert!(result.is_valid(), "hwloc returned invalid flags");

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -47,6 +47,7 @@ use std::{
     ptr::{self, NonNull},
     sync::OnceLock,
 };
+use strum::IntoEnumIterator;
 use thiserror::Error;
 
 /// Main entry point to the hwloc API
@@ -387,7 +388,8 @@ impl Topology {
         errors::call_hwloc_int_normal("hwloc_topology_get_type_filter", || unsafe {
             hwlocality_sys::hwloc_topology_get_type_filter(self.as_ptr(), ty.into(), &mut filter)
         })?;
-        Ok(TypeFilter::try_from(filter).expect("Unexpected type filter from hwloc"))
+        // SAFETY: Filter is from a successful hwloc API call
+        Ok(unsafe { TypeFilter::from_hwloc(filter) })
     }
 }
 
@@ -958,7 +960,7 @@ impl Debug for Topology {
             .field("build_flags", &self.build_flags())
             .field("is_this_system", &self.is_this_system())
             .field("feature_support", self.feature_support());
-        let type_filters = enum_iterator::all::<ObjectType>()
+        let type_filters = ObjectType::iter()
             .map(|ty| {
                 (
                     format!("{ty}"),
@@ -1052,7 +1054,7 @@ impl PartialEq for Topology {
         fn type_filters(
             topology: &Topology,
         ) -> impl Iterator<Item = Result<TypeFilter, RawHwlocError>> + '_ {
-            enum_iterator::all::<ObjectType>().map(|ty| topology.type_filter(ty))
+            ObjectType::iter().map(|ty| topology.type_filter(ty))
         }
         if !type_filters(self).eq(type_filters(other)) {
             return false;

--- a/tests/single-threaded.rs
+++ b/tests/single-threaded.rs
@@ -36,6 +36,7 @@ use std::{
     ops::{Deref, DerefMut},
     ptr,
 };
+use strum::IntoEnumIterator;
 use tracing_error::{ErrorLayer, SpanTrace, SpanTraceStatus};
 use tracing_subscriber::prelude::*;
 
@@ -660,6 +661,7 @@ fn post_bind_checks<Set: SpecializedBitmap, Res: Debug>(
             MemoryBindingPolicy::FirstTouch => membind_support.first_touch_policy(),
             MemoryBindingPolicy::Interleave => membind_support.interleave_policy(),
             MemoryBindingPolicy::NextTouch => membind_support.next_touch_policy(),
+            MemoryBindingPolicy::Unknown(_) => false,
         };
         if !policy_supported {
             return Ok(None);
@@ -1432,7 +1434,7 @@ fn any_cpubind_flags() -> impl Strategy<Value = CpuBindingFlags> {
 
 /// Generate an arbitrary memory binding policy
 fn any_membind_policy() -> impl Strategy<Value = MemoryBindingPolicy> {
-    let policies = enum_iterator::all::<MemoryBindingPolicy>().collect::<Vec<_>>();
+    let policies = MemoryBindingPolicy::iter().collect::<Vec<_>>();
     prop::sample::select(policies)
 }
 


### PR DESCRIPTION
This PR tries to resolve #259 in the following manner:

- All Rust enums matching hwloc enums now have an `Unknown()` variant, which contains an `UnknownVariant` type that can be read by the user but cannot be constructed.
- For all enums studied so far, it seems safe to send an unknown variant from hwloc back to hwloc. Therefore this is allowed.
- Rust enums mapping hwloc enums cannot be user-constructed via `TryFrom` anymore, as this is necessary for the above safety contract to work.
- Replaced `num_enum` and `enum_iterator`, which couldn't handle `UnknownVariant` payloads, with `strum`.
- Made bitflags also retain unknown hwloc flags for consistency.
- Since we now have a "valid representation from hwloc" invariant, stopped generating invalid representations in tests.

Fixes #259 .