### PR TITLE
Test polish

### DIFF
--- a/src/bitmap/cow.rs
+++ b/src/bitmap/cow.rs
@@ -126,7 +126,7 @@ mod tests {
     use proptest::prelude::*;
     #[allow(unused)]
     use similar_asserts::assert_eq;
-    use std::hash::{BuildHasher, RandomState};
+    use std::{collections::hash_map::RandomState, hash::BuildHasher};
 
     // Test BitmapCow construction and intrinsic properties
     proptest! {

--- a/src/bitmap/newtypes.rs
+++ b/src/bitmap/newtypes.rs
@@ -696,6 +696,7 @@ macro_rules! impl_bitmap_newtype {
                 trivial_casts
             )]
             #[cfg(test)]
+            #[cfg(not(tarpaulin_include))]
             mod tests {
                 use super::*;
                 use $crate::{

--- a/src/bitmap/newtypes.rs
+++ b/src/bitmap/newtypes.rs
@@ -2,14 +2,16 @@
 
 #[cfg(doc)]
 use super::BitmapRef;
-use super::{hwloc_bitmap_s, Bitmap};
+use super::{hwloc_bitmap_s, Bitmap, BitmapIndex};
 use crate::Sealed;
 #[cfg(doc)]
 use crate::{cpu::cpuset::CpuSet, memory::nodeset::NodeSet};
 use std::{
     borrow::{Borrow, BorrowMut},
     fmt::{Debug, Display, Pointer},
-    ops::Deref,
+    hash::Hash,
+    ops::{BitAnd, BitOr, BitXor, Deref, Not, Sub, SubAssign},
+    panic::UnwindSafe,
     ptr::NonNull,
 };
 
@@ -28,16 +30,33 @@ use std::{
 // `NonNull<hwloc_bitmap_s>`, possibly with some ZSTs added.
 #[allow(clippy::missing_safety_doc)]
 pub unsafe trait OwnedBitmap:
-    Borrow<Bitmap>
+    BitAnd
+    + BitOr
+    + BitXor
     + BorrowMut<Bitmap>
     + Clone
     + Debug
+    + Default
     + Display
+    + Eq
+    + Extend<BitmapIndex>
     + From<Bitmap>
+    + From<BitmapIndex>
+    + FromIterator<BitmapIndex>
+    + Hash
     + Into<Bitmap>
+    + IntoIterator<Item = BitmapIndex>
+    + Not
+    + Ord
     + PartialEq
     + Pointer
     + Sealed
+    + Sized
+    + Sub
+    + SubAssign
+    + Sync
+    + Unpin
+    + UnwindSafe
     + 'static
 {
     /// Access the inner `NonNull<hwloc_bitmap_s>`
@@ -70,7 +89,7 @@ unsafe impl OwnedBitmap for Bitmap {
 /// See also [`SpecializedBitmapRef`].
 #[doc(alias = "HWLOC_MEMBIND_BYNODESET")]
 #[doc(alias = "HWLOC_RESTRICT_FLAG_BYNODESET")]
-pub trait SpecializedBitmap: OwnedBitmap {
+pub trait SpecializedBitmap: OwnedBitmap + AsMut<Bitmap> {
     /// Tag used to discriminate between specialized bitmaps in code
     const BITMAP_KIND: BitmapKind;
 }

--- a/src/cpu/binding.rs
+++ b/src/cpu/binding.rs
@@ -955,6 +955,7 @@ pub(crate) fn call_hwloc(
                 // Using errno documentation from
                 // https://hwloc.readthedocs.io/en/stable/group__hwlocality__cpubinding.html
                 ENOSYS => Err(CpuBindingError::BadObject(object).into()),
+                #[cfg(not(tarpaulin_include))]
                 EXDEV => Err(CpuBindingError::UnsupportedCpuSet(
                     object,
                     cpuset

--- a/src/cpu/cpuset.rs
+++ b/src/cpu/cpuset.rs
@@ -274,6 +274,7 @@ impl Topology {
                         }
                     }
                 }
+                #[cfg(not(tarpaulin_include))]
                 assert!(
                     !ptr::eq(parent, old_parent),
                     "This should not happen because...\n\

--- a/src/cpu/kind.rs
+++ b/src/cpu/kind.rs
@@ -174,6 +174,7 @@ impl Topology {
             }
         };
         let infos = if infos.is_null() {
+            #[cfg(not(tarpaulin_include))]
             assert_eq!(
                 nr_infos, 0,
                 "hwloc pretended to yield {nr_infos} infos but provided a null infos pointer"
@@ -358,6 +359,7 @@ impl TopologyEditor<'_> {
 
             // Translate number of infos into hwloc's preferred format
             let infos_ptr = raw_infos.as_ptr();
+            #[cfg(not(tarpaulin_include))]
             let num_infos =
                 c_uint::try_from(raw_infos.len()).map_err(|_| RegisterError::TooManyInfos)?;
 

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -103,12 +103,14 @@ pub(crate) unsafe fn call_snprintf(
         let len =
             usize::try_from(len_i32).expect("Got invalid string length from an snprintf-like API");
         let mut buf = vec![0; len + 1];
+        #[cfg(not(tarpaulin_include))]
         assert_eq!(
             // SAFETY: Per input precondition
             snprintf(buf.as_mut_ptr(), buf.len()),
             len_i32,
             "Got inconsistent string length from an snprintf-like API"
         );
+        #[cfg(not(tarpaulin_include))]
         assert_eq!(
             buf.last().copied(),
             Some(0),

--- a/src/ffi/string.rs
+++ b/src/ffi/string.rs
@@ -46,6 +46,7 @@ impl LibcString {
 
             // Make sure the output C string would follow Rust's rules
             let len = s.len() + 1;
+            #[cfg(not(tarpaulin_include))]
             assert!(
                 len < isize::MAX as usize,
                 "Cannot add a final NUL without breaking Rust's slice requirements"

--- a/src/ffi/unknown.rs
+++ b/src/ffi/unknown.rs
@@ -47,3 +47,18 @@ impl<T> UnknownVariant<T> {
         self.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    #[allow(unused)]
+    use similar_asserts::assert_eq;
+
+    proptest! {
+        #[test]
+        fn unknown_get(v: u64) {
+            prop_assert_eq!(UnknownVariant(v).get(), v);
+        }
+    }
+}

--- a/src/memory/binding.rs
+++ b/src/memory/binding.rs
@@ -1156,6 +1156,7 @@ impl Topology {
                 // SAFETY: Per function precondition
                 match unsafe { MemoryBindingPolicy::from_hwloc(raw_policy) } {
                     MemoryBindingPolicy::Unknown(UnknownVariant(HWLOC_MEMBIND_MIXED)) => None,
+                    #[cfg(not(tarpaulin_include))]
                     MemoryBindingPolicy::Unknown(UnknownVariant(err)) if err < 0 => {
                         panic!("Got unexpected negative memory policy #{err}")
                     }
@@ -1666,6 +1667,7 @@ fn decode_errno<Set: SpecializedBitmap>(
     match errno {
         Some(Errno(ENOSYS)) => Some(MemoryBindingError::Unsupported),
         Some(Errno(EXDEV)) => match operation {
+            #[cfg(not(tarpaulin_include))]
             MemoryBindingOperation::Bind | MemoryBindingOperation::Allocate => {
                 Some(MemoryBindingError::BadSet(
                     object,
@@ -1680,6 +1682,7 @@ fn decode_errno<Set: SpecializedBitmap>(
                 unreachable!("The empty set should always be considered valid")
             }
         },
+        #[cfg(not(tarpaulin_include))]
         Some(Errno(ENOMEM)) => Some(MemoryBindingError::AllocationFailed),
         #[cfg(windows)]
         // Work around CRT mismatch issues on Windows, which break errno
@@ -1794,6 +1797,7 @@ impl Drop for Bytes<'_> {
                     len,
                 )
             });
+            #[cfg(not(tarpaulin_include))]
             if let Err(e) = result {
                 // Cannot panic in Drop
                 eprintln!("ERROR: Failed to liberate hwloc allocation ({e}).",);

--- a/src/memory/binding.rs
+++ b/src/memory/binding.rs
@@ -1540,7 +1540,7 @@ impl From<MemoryBindingPolicy> for hwloc_membind_policy_t {
             #[cfg(feature = "hwloc-2_11_0")]
             MemoryBindingPolicy::WeightedInterleave => HWLOC_MEMBIND_WEIGHTED_INTERLEAVE,
             MemoryBindingPolicy::NextTouch => HWLOC_MEMBIND_NEXTTOUCH,
-            MemoryBindingPolicy::Unknown(unknown) => unknown.0,
+            MemoryBindingPolicy::Unknown(unknown) => unknown.get(),
         }
     }
 }

--- a/src/object/attributes/group.rs
+++ b/src/object/attributes/group.rs
@@ -71,6 +71,7 @@ impl GroupAttributes {
     /// parent or children
     #[cfg(feature = "hwloc-2_0_4")]
     pub fn merging_prevented(&self) -> bool {
+        #[cfg(not(tarpaulin_include))]
         assert!(
             self.0.dont_merge == 0 || self.0.dont_merge == 1,
             "unexpected hwloc_group_attr_s::dont_merge value"

--- a/src/object/attributes/numa.rs
+++ b/src/object/attributes/numa.rs
@@ -56,6 +56,7 @@ impl<'object> NUMANodeAttributes<'object> {
     #[doc(alias = "hwloc_obj_attr_u::hwloc_numanode_attr_s::page_types")]
     pub fn page_types(&self) -> &'object [MemoryPageType] {
         if self.0.page_types.is_null() {
+            #[cfg(not(tarpaulin_include))]
             assert_eq!(
                 self.0.page_types_len, 0,
                 "Got null pages types pointer with non-zero length"

--- a/src/object/depth.rs
+++ b/src/object/depth.rs
@@ -161,7 +161,7 @@ impl Depth {
             Self::Misc => HWLOC_TYPE_DEPTH_MISC,
             #[cfg(feature = "hwloc-2_1_0")]
             Self::MemCache => HWLOC_TYPE_DEPTH_MEMCACHE,
-            Self::Unknown(unknown) => unknown.0,
+            Self::Unknown(unknown) => unknown.get(),
         }
     }
 }

--- a/src/object/distance.rs
+++ b/src/object/distance.rs
@@ -1589,7 +1589,7 @@ impl From<DistancesTransform> for hwloc_distances_transform_e {
             DistancesTransform::TransitiveSwitchClosure => {
                 HWLOC_DISTANCES_TRANSFORM_TRANSITIVE_CLOSURE
             }
-            DistancesTransform::Unknown(unknown) => unknown.0,
+            DistancesTransform::Unknown(unknown) => unknown.get(),
         }
     }
 }

--- a/src/object/hierarchy.rs
+++ b/src/object/hierarchy.rs
@@ -205,6 +205,7 @@ impl Topology {
                 // First depth above + 1 is first depth below
                 Ok(Depth::from(first_depth_above + 1))
             }
+            #[cfg(not(tarpaulin_include))]
             other_err => other_err,
         }
     }
@@ -269,6 +270,7 @@ impl Topology {
                 // First depth below - 1 is first depth above
                 Ok(Depth::from(first_depth_below - 1))
             }
+            #[cfg(not(tarpaulin_include))]
             other_err => other_err,
         }
     }

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -575,6 +575,7 @@ impl TopologyObject {
         &self,
     ) -> impl DoubleEndedIterator<Item = &Self> + Clone + ExactSizeIterator + FusedIterator {
         if self.0.children.is_null() {
+            #[cfg(not(tarpaulin_include))]
             assert_eq!(
                 self.normal_arity(),
                 0,
@@ -584,6 +585,7 @@ impl TopologyObject {
         (0..self.normal_arity()).map(move |offset| {
             // SAFETY: Pointer is in bounds by construction
             let child = unsafe { *self.0.children.add(offset) };
+            #[cfg(not(tarpaulin_include))]
             assert!(!child.is_null(), "Got null child pointer");
             // SAFETY: - We checked that the pointer isn't null
             //         - Pointer & target validity assumed as a type invariant
@@ -728,6 +730,7 @@ impl TopologyObject {
     ) -> impl ExactSizeIterator<Item = &Self> + Clone + FusedIterator {
         let mut current = first;
         (0..arity).map(move |_| {
+            #[cfg(not(tarpaulin_include))]
             assert!(!current.is_null(), "Got null child before expected arity");
             // SAFETY: - We checked that the pointer isn't null
             //         - Pointer & target validity assumed as a type invariant
@@ -924,6 +927,7 @@ impl TopologyObject {
     pub fn infos(&self) -> &[TextualInfo] {
         // Handle null infos pointer
         if self.0.infos.is_null() {
+            #[cfg(not(tarpaulin_include))]
             assert_eq!(
                 self.0.infos_count, 0,
                 "Got null infos pointer with nonzero info count"

--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -88,7 +88,7 @@ impl From<BridgeType> for hwloc_obj_bridge_type_t {
         match value {
             BridgeType::Host => HWLOC_OBJ_BRIDGE_HOST,
             BridgeType::PCI => HWLOC_OBJ_BRIDGE_PCI,
-            BridgeType::Unknown(unknown) => unknown.0,
+            BridgeType::Unknown(unknown) => unknown.get(),
         }
     }
 }
@@ -145,7 +145,7 @@ impl From<CacheType> for hwloc_obj_cache_type_t {
             CacheType::Unified => HWLOC_OBJ_CACHE_UNIFIED,
             CacheType::Data => HWLOC_OBJ_CACHE_DATA,
             CacheType::Instruction => HWLOC_OBJ_CACHE_INSTRUCTION,
-            CacheType::Unknown(unknown) => unknown.0,
+            CacheType::Unknown(unknown) => unknown.get(),
         }
     }
 }
@@ -241,7 +241,7 @@ impl From<OSDeviceType> for hwloc_obj_osdev_type_t {
             OSDeviceType::CoProcessor => HWLOC_OBJ_OSDEV_COPROC,
             #[cfg(feature = "hwloc-3_0_0")]
             OSDeviceType::Memory => HWLOC_OBJ_OSDEV_MEMORY,
-            OSDeviceType::Unknown(unknown) => unknown.0,
+            OSDeviceType::Unknown(unknown) => unknown.get(),
         }
     }
 }
@@ -632,7 +632,7 @@ impl From<ObjectType> for hwloc_obj_type_t {
             ObjectType::MemCache => HWLOC_OBJ_MEMCACHE,
             #[cfg(feature = "hwloc-2_1_0")]
             ObjectType::Die => HWLOC_OBJ_DIE,
-            ObjectType::Unknown(unknown) => unknown.0,
+            ObjectType::Unknown(unknown) => unknown.get(),
         }
     }
 }

--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -88,6 +88,7 @@ impl From<BridgeType> for hwloc_obj_bridge_type_t {
         match value {
             BridgeType::Host => HWLOC_OBJ_BRIDGE_HOST,
             BridgeType::PCI => HWLOC_OBJ_BRIDGE_PCI,
+            #[cfg(not(tarpaulin_include))]
             BridgeType::Unknown(unknown) => unknown.get(),
         }
     }
@@ -145,6 +146,7 @@ impl From<CacheType> for hwloc_obj_cache_type_t {
             CacheType::Unified => HWLOC_OBJ_CACHE_UNIFIED,
             CacheType::Data => HWLOC_OBJ_CACHE_DATA,
             CacheType::Instruction => HWLOC_OBJ_CACHE_INSTRUCTION,
+            #[cfg(not(tarpaulin_include))]
             CacheType::Unknown(unknown) => unknown.get(),
         }
     }
@@ -241,6 +243,7 @@ impl From<OSDeviceType> for hwloc_obj_osdev_type_t {
             OSDeviceType::CoProcessor => HWLOC_OBJ_OSDEV_COPROC,
             #[cfg(feature = "hwloc-3_0_0")]
             OSDeviceType::Memory => HWLOC_OBJ_OSDEV_MEMORY,
+            #[cfg(not(tarpaulin_include))]
             OSDeviceType::Unknown(unknown) => unknown.get(),
         }
     }

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -1563,7 +1563,7 @@ pub(crate) mod tests {
                     .unwrap()
                     .from_xml_file(&bad_path);
                 if cfg!(windows) {
-                    prop_assert!(res.unwrap().build().is_err());
+                    prop_assert!(res.is_err() || res.unwrap().build().is_err());
                 } else {
                     prop_assert!(matches!(
                         res,

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -1541,7 +1541,7 @@ pub(crate) mod tests {
                 check_xml_topology(&topology)?;
             }
 
-            // Test round trip throguh XML file
+            // Test round trip through XML file
             {
                 let path = NamedTempFile::new().unwrap().into_temp_path();
                 default

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -192,13 +192,16 @@ impl TopologyBuilder {
                 hwloc_pid_t::try_from(pid).expect("shouldn't fail for a valid PID"),
             )
         });
+        #[cfg(not(tarpaulin_include))]
         let handle_enosys = || Err(FromPIDError(pid).into());
         match result {
             Ok(()) => Ok(self),
+            #[cfg(not(tarpaulin_include))]
             Err(RawHwlocError {
                 errno: Some(Errno(ENOSYS)),
                 ..
             }) => handle_enosys(),
+            #[cfg(not(tarpaulin_include))]
             #[cfg(windows)]
             Err(RawHwlocError { errno: None, .. }) => {
                 // As explained in the RawHwlocError documentation, errno values

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -1563,7 +1563,7 @@ pub(crate) mod tests {
                     .unwrap()
                     .from_xml_file(&bad_path);
                 // For unknown reasons, hwloc does not always detect that the
-                // XML file path doesn't exist.
+                // XML file is empty ahead of time.
                 if res.is_err() {
                     prop_assert!(matches!(
                         res,

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -1555,6 +1555,18 @@ pub(crate) mod tests {
                     .unwrap();
                 check_xml_topology(&topology)?;
             }
+
+            // Test invalid XML file load
+            {
+                let bad_path = NamedTempFile::new().unwrap().into_temp_path();
+                let res = builder_with_flags(build_flags)?
+                    .unwrap()
+                    .from_xml_file(&bad_path);
+                prop_assert!(matches!(
+                    res,
+                    Err(FileInputError::Invalid(path)) if *path == *bad_path,
+                ));
+            }
         }
 
         /// Add a targeted type filter

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -1562,10 +1562,14 @@ pub(crate) mod tests {
                 let res = builder_with_flags(build_flags)?
                     .unwrap()
                     .from_xml_file(&bad_path);
-                prop_assert!(matches!(
-                    res,
-                    Err(FileInputError::Invalid(path)) if *path == *bad_path,
-                ));
+                if cfg!(windows) {
+                    prop_assert!(res.unwrap().build().is_err());
+                } else {
+                    prop_assert!(matches!(
+                        res,
+                        Err(FileInputError::Invalid(path)) if *path == *bad_path,
+                    ));
+                }
             }
         }
 

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -1003,7 +1003,7 @@ impl From<TypeFilter> for hwloc_type_filter_e {
             TypeFilter::KeepNone => HWLOC_TYPE_FILTER_KEEP_NONE,
             TypeFilter::KeepStructure => HWLOC_TYPE_FILTER_KEEP_STRUCTURE,
             TypeFilter::KeepImportant => HWLOC_TYPE_FILTER_KEEP_IMPORTANT,
-            TypeFilter::Unknown(unknown) => unknown.0,
+            TypeFilter::Unknown(unknown) => unknown.get(),
         }
     }
 }

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -1562,13 +1562,15 @@ pub(crate) mod tests {
                 let res = builder_with_flags(build_flags)?
                     .unwrap()
                     .from_xml_file(&bad_path);
-                if cfg!(windows) {
-                    prop_assert!(res.is_err() || res.unwrap().build().is_err());
-                } else {
+                // For unknown reasons, hwloc does not always detect that the
+                // XML file path doesn't exist.
+                if res.is_err() {
                     prop_assert!(matches!(
                         res,
                         Err(FileInputError::Invalid(path)) if *path == *bad_path,
                     ));
+                } else {
+                    prop_assert!(res.unwrap().build().is_err());
                 }
             }
         }

--- a/src/topology/editor.rs
+++ b/src/topology/editor.rs
@@ -119,6 +119,7 @@ impl Topology {
         let result = errors::call_hwloc_zero_or_minus1("hwloc_topology_refresh", || unsafe {
             hwlocality_sys::hwloc_topology_refresh(self.as_mut_ptr())
         });
+        #[cfg(not(tarpaulin_include))]
         if let Err(e) = result {
             eprintln!("ERROR: Failed to refresh topology ({e}), so it's stuck in a state that violates Rust aliasing rules. Must abort...");
             std::process::abort()
@@ -299,6 +300,7 @@ impl<'topology> TopologyEditor<'topology> {
                     flags.bits(),
                 )
             });
+            #[cfg(not(tarpaulin_include))]
             let handle_enomem = |certain: bool| {
                 let nuance = if certain { "is" } else { "might be" };
                 eprintln!("ERROR: Topology {nuance} stuck in an invalid state. Must abort...");
@@ -312,9 +314,12 @@ impl<'topology> TopologyEditor<'topology> {
                     },
                 ) => match errno.0 {
                     EINVAL => Err(ParameterError::from(set.to_owned())),
+                    #[cfg(not(tarpaulin_include))]
                     ENOMEM => handle_enomem(true),
+                    #[cfg(not(tarpaulin_include))]
                     _ => unreachable!("Unexpected hwloc error: {raw_err}"),
                 },
+                #[cfg(not(tarpaulin_include))]
                 Err(raw_err @ RawHwlocError { errno: None, .. }) => {
                     if cfg!(windows) {
                         // Due to errno propagation issues on windows, we may not
@@ -407,6 +412,7 @@ impl<'topology> TopologyEditor<'topology> {
         });
         match result {
             Ok(()) => Ok(()),
+            #[cfg(not(tarpaulin_include))]
             Err(RawHwlocError {
                 errno: Some(Errno(ENOSYS)),
                 ..
@@ -705,6 +711,7 @@ impl<'topology> TopologyEditor<'topology> {
             let Some(obj_name) = obj.name() else {
                 return false;
             };
+            #[cfg(not(tarpaulin_include))]
             let Ok(obj_name) = obj_name.to_str() else {
                 return false;
             };
@@ -727,6 +734,7 @@ impl<'topology> TopologyEditor<'topology> {
     }
 }
 
+#[cfg(not(tarpaulin_include))]
 bitflags! {
     /// Flags to be given to [`TopologyEditor::restrict()`]
     #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
@@ -1327,16 +1335,19 @@ impl<'editor, 'topology> AllocatedGroup<'editor, 'topology> {
                             child.as_inner(),
                         )
                     });
+                #[cfg(not(tarpaulin_include))]
                 let handle_enomem =
                     |raw_err: RawHwlocError| panic!("Internal reallocation failed: {raw_err}");
                 match result {
                     Ok(()) => {}
+                    #[cfg(not(tarpaulin_include))]
                     Err(
                         raw_err @ RawHwlocError {
                             errno: Some(errno::Errno(ENOMEM)),
                             ..
                         },
                     ) => handle_enomem(raw_err),
+                    #[cfg(not(tarpaulin_include))]
                     #[cfg(windows)]
                     Err(raw_err @ RawHwlocError { errno: None, .. }) => {
                         // As explained in the RawHwlocError documentation,
@@ -1417,16 +1428,18 @@ impl<'editor, 'topology> AllocatedGroup<'editor, 'topology> {
             });
             match result {
                 Ok(()) => Ok(()),
+                #[cfg(not(tarpaulin_include))]
                 Err(RawHwlocError {
                     api: "hwloc_obj_set_subtype",
                     errno: Some(Errno(ENOMEM)),
                 }) => panic!("Ran out of memory while calling hwloc_obj_set_subtype()"),
+                #[cfg(not(tarpaulin_include))]
                 #[cfg(windows)]
                 Err(RawHwlocError {
                     api: "hwloc_obj_set_subtype",
                     errno: None,
                 }) => panic!("Ran out of memory while calling hwloc_obj_set_subtype()"),
-                Err(error) => panic!(
+                Err(error) => unreachable!(
                     "Encountered unexpected error {error} while calling hwloc_obj_set_subtype()"
                 ),
             }
@@ -1543,6 +1556,7 @@ impl Drop for AllocatedGroup<'_, '_> {
                     )
                 },
             );
+            #[cfg(not(tarpaulin_include))]
             if let Err(e) = result {
                 eprintln!("ERROR: Failed to deallocate group object ({e}).");
             }

--- a/src/topology/export/xml.rs
+++ b/src/topology/export/xml.rs
@@ -191,6 +191,7 @@ impl<'topology> XML<'topology> {
         let s = unsafe { CStr::from_ptr(base) };
         s.to_str()
             .expect("Unexpected non-UTF8 XML string from hwloc");
+        #[cfg(not(tarpaulin_include))]
         assert_eq!(
             s.to_bytes_with_nul().len(),
             len,

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -231,7 +231,8 @@ impl Topology {
                 errno: Some(Errno(EINVAL)),
                 ..
             }) => false,
-            #[cfg(all(windows, not(tarpaulin_include)))]
+            #[cfg(not(tarpaulin_include))]
+            #[cfg(windows)]
             Err(RawHwlocError { errno: None, .. }) => {
                 // As explained in the RawHwlocError documentation, errno values
                 // may not correctly propagate from hwloc to hwlocality on
@@ -487,11 +488,13 @@ impl Topology {
             result: &mut Vec<CpuSet>,
         ) {
             // Debug mode checks
+            #[cfg(not(tarpaulin_include))]
             debug_assert_ne!(
                 roots_and_cpusets.clone().count(),
                 0,
                 "Can't distribute to 0 roots"
             );
+            #[cfg(not(tarpaulin_include))]
             debug_assert_ne!(
                 num_items, 0,
                 "Shouldn't try to distribute 0 items (just don't call this function)"
@@ -557,6 +560,7 @@ impl Topology {
             }
 
             // Debug mode checks
+            #[cfg(not(tarpaulin_include))]
             debug_assert_eq!(
                 result.len() - initial_len,
                 num_items,
@@ -581,6 +585,7 @@ impl Topology {
         // Run the recursion, collect results
         let mut result = Vec::with_capacity(num_items);
         recurse(decoded_roots, num_items, max_depth, flags, &mut result);
+        #[cfg(not(tarpaulin_include))]
         debug_assert_eq!(
             result.len(),
             num_items,


### PR DESCRIPTION
Did a review of the current uncovered lines in codecov and...

- Added tests for true uncovered code
- Masked away code that CI couldn't realistically exercise (e.g. OOM)
- Performed minor unrelated cleanup (e.g. fleshed out the OwnedBitmap sealed trait, which is not a breaking change because it's sealed)