### PR TITLE
Remove obsolete clippy::string_to_string lint, now merged into clippy…

### DIFF
--- a/hwlocality-sys/src/lib.rs
+++ b/hwlocality-sys/src/lib.rs
@@ -123,7 +123,6 @@
     clippy::str_to_string,
     clippy::string_add,
     clippy::string_lit_as_bytes,
-    clippy::string_to_string,
     clippy::suboptimal_flops,
     clippy::suspicious_operation_groupings,
     clippy::tests_outside_test_module,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,6 @@
     clippy::str_to_string,
     clippy::string_add,
     clippy::string_lit_as_bytes,
-    clippy::string_to_string,
     clippy::suboptimal_flops,
     //
     clippy::todo,


### PR DESCRIPTION
…::implicit_clone