### PR TITLE
MSRV/edition/deps update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
   RUSTFLAGS: '-D warnings'
   RUSTDOCFLAGS: '-D warnings'
   RUST_LOG: 'info'
-  MINIMAL_RUST: '1.84.0'  # Minimal Supported Rust Version
+  MINIMAL_RUST: '1.85.0'  # Minimal Supported Rust Version
   HWLOC_VERSION: '2.13.0'
   HWLOC_VERSION_SHORT: '2.13'  # Used in URL to official tarball/binaries
   HWLOC_DEBUG_VERBOSE: 0  # Set to 1 when debugging issues inside of hwloc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hwlocality"
-version = "1.0.0-alpha.11"
+version = "1.0.0-alpha.12"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "hwlocality-sys"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "autotools",
  "cmake",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,11 +49,11 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -69,9 +75,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -104,6 +110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -132,12 +144,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -165,11 +176,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -178,6 +190,12 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -201,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
 
 [[package]]
 name = "filetime"
@@ -233,14 +251,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
@@ -261,9 +275,37 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -328,23 +370,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
-name = "itoa"
-version = "1.0.17"
+name = "indexmap"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "keccak"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
+ "cfg-if",
  "cpufeatures",
 ]
 
@@ -355,6 +425,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,9 +438,9 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags",
  "libc",
@@ -439,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "percent-encoding"
@@ -477,6 +553,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bitflags",
  "num-traits",
@@ -514,6 +600,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -647,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -681,10 +773,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.10.8"
+name = "serde_json"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest",
  "keccak",
@@ -707,9 +812,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
@@ -807,7 +912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -914,9 +1019,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -932,9 +1037,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
  "flate2",
@@ -943,15 +1048,15 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
  "webpki-roots",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64",
  "http",
@@ -960,16 +1065,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
+name = "utf8-zero"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "wasi"
@@ -979,11 +1078,54 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1218,9 +1360,97 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "xattr"
@@ -1234,18 +1464,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1257,3 +1487,9 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,15 +3,15 @@ members = ["hwlocality-sys"]
 
 [workspace.package]
 authors = ["Hadrien G. <knights_of_ni@gmx.com>", "Joseph Hirschfeld <j@ibj.io>", "Michael Nitschinger <michael@nitschinger.at>"]
-edition = "2021"
-rust-version = "1.84.0"
+edition = "2024"
+rust-version = "1.85.0"
 repository = "https://github.com/HadrienG2/hwlocality"
 license = "MIT"
 keywords = ["hwloc", "locality", "cache", "numa", "hardware"]
 categories = ["concurrency", "external-ffi-bindings", "hardware-support", "memory-management", "os"]
 
 [workspace.dependencies]
-proptest = { version = "1.10", default-features = false, features = ["std"] }
+proptest = { version = "1.11", default-features = false, features = ["std"] }
 libc = "0.2"
 static_assertions = "1.1"
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading"] }
@@ -245,7 +245,7 @@ windows-sys.workspace = true
 eyre = "0.6"
 
 # Used to ease debugging of string tests
-similar-asserts = "1.7"
+similar-asserts = "2.0"
 
 # Used for random testing
 proptest.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ overflow-checks = false
 
 [package]
 name = "hwlocality"
-version = "1.0.0-alpha.11"
+version = "1.0.0-alpha.12"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Code coverage](https://codecov.io/gh/HadrienG2/hwlocality/graph/badge.svg?token=OYWLNUD9AI)](https://codecov.io/gh/HadrienG2/hwlocality)
 [![CII Best Practices Summary](https://img.shields.io/cii/summary/7876)](https://www.bestpractices.dev/en/projects/7876)
 ![Requires rustc
-1.82.0+](https://img.shields.io/badge/rustc-1.84.0+-lightgray.svg)
+1.85.0+](https://img.shields.io/badge/rustc-1.85.0+-lightgray.svg)
 
 ## What is this?
 

--- a/examples/allocate_bound.rs
+++ b/examples/allocate_bound.rs
@@ -1,8 +1,8 @@
 use eyre::eyre;
 use hwlocality::{
-    memory::binding::{MemoryBindingFlags, MemoryBindingPolicy},
-    object::{depth::Depth, TopologyObject},
     Topology,
+    memory::binding::{MemoryBindingFlags, MemoryBindingPolicy},
+    object::{TopologyObject, depth::Depth},
 };
 
 /// Allocate 4 MiB of memory that is bound to the last NUMA node on the system

--- a/examples/bind_process_cpu.rs
+++ b/examples/bind_process_cpu.rs
@@ -1,8 +1,8 @@
 use eyre::eyre;
 use hwlocality::{
-    cpu::binding::CpuBindingFlags,
-    object::{types::ObjectType, TopologyObject},
     Topology,
+    cpu::binding::CpuBindingFlags,
+    object::{TopologyObject, types::ObjectType},
 };
 
 /// Example which binds an arbitrary process (in this example this very same one)

--- a/examples/bind_threads_cpu.rs
+++ b/examples/bind_threads_cpu.rs
@@ -1,9 +1,9 @@
 use eyre::eyre;
 use hwlocality::{
+    Topology,
     cpu::binding::CpuBindingFlags,
     object::types::ObjectType,
     topology::support::{DiscoverySupport, FeatureSupport},
-    Topology,
 };
 
 /// Example which spawns one thread per core and then assigns it to each.

--- a/examples/bind_to_last_core.rs
+++ b/examples/bind_to_last_core.rs
@@ -1,8 +1,8 @@
 use eyre::eyre;
 use hwlocality::{
-    cpu::binding::CpuBindingFlags,
-    object::{types::ObjectType, TopologyObject},
     Topology,
+    cpu::binding::CpuBindingFlags,
+    object::{TopologyObject, types::ObjectType},
 };
 
 /// Bind to the CPU last core of the machine.

--- a/examples/number_of_packages.rs
+++ b/examples/number_of_packages.rs
@@ -1,6 +1,6 @@
 use hwlocality::{
-    object::{depth::TypeToDepthError, types::ObjectType},
     Topology,
+    object::{depth::TypeToDepthError, types::ObjectType},
 };
 
 /// Prints the number of packages.

--- a/examples/process_cpu_bindings.rs
+++ b/examples/process_cpu_bindings.rs
@@ -1,12 +1,12 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use hwlocality::{
+    ProcessId, Topology,
     cpu::{binding::CpuBindingFlags, cpuset::CpuSet},
     topology::{
         builder::BuildFlags,
         support::{CpuBindingSupport, FeatureSupport},
     },
-    ProcessId, Topology,
 };
 use sysinfo::{ProcessRefreshKind, RefreshKind, System};
 

--- a/examples/processor_cache.rs
+++ b/examples/processor_cache.rs
@@ -1,7 +1,7 @@
 use eyre::eyre;
 use hwlocality::{
-    object::{attributes::ObjectAttributes, types::ObjectType},
     Topology,
+    object::{attributes::ObjectAttributes, types::ObjectType},
 };
 
 /// Compute the amount of cache that the first logical processor

--- a/examples/support.rs
+++ b/examples/support.rs
@@ -1,6 +1,6 @@
 use hwlocality::{
-    topology::support::{CpuBindingSupport, FeatureSupport, MemoryBindingSupport},
     Topology,
+    topology::support::{CpuBindingSupport, FeatureSupport, MemoryBindingSupport},
 };
 
 /// Example on how to check for specific topology support of a feature.

--- a/examples/walk_linear.rs
+++ b/examples/walk_linear.rs
@@ -1,4 +1,4 @@
-use hwlocality::{object::depth::NormalDepth, Topology};
+use hwlocality::{Topology, object::depth::NormalDepth};
 
 /// Walk the topology with an array style, from depth 0 (always Machine)
 /// to the lowest depth (always logical processors).

--- a/examples/walk_tree.rs
+++ b/examples/walk_tree.rs
@@ -1,4 +1,4 @@
-use hwlocality::{object::TopologyObject, Topology};
+use hwlocality::{Topology, object::TopologyObject};
 
 /// Walk the topologylogy in a tree-style and print it.
 fn main() -> eyre::Result<()> {

--- a/hwlocality-sys/Cargo.toml
+++ b/hwlocality-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hwlocality-sys"
-version = "0.6.4"
+version = "0.7.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/hwlocality-sys/Cargo.toml
+++ b/hwlocality-sys/Cargo.toml
@@ -45,7 +45,7 @@ pkg-config = "0.3.32"
 
 # Used for vendored builds on all OSes
 flate2 = { version = "1.1", optional = true }
-sha3 = { version = "0.10.8", optional = true }
+sha3 = { version = "0.11.0", optional = true }
 tar = { version = "0.4", optional = true }
 ureq = { version = "3.2", optional = true }
 

--- a/hwlocality-sys/README.md
+++ b/hwlocality-sys/README.md
@@ -6,7 +6,7 @@
 [![Continuous Integration](https://img.shields.io/github/actions/workflow/status/HadrienG2/hwlocality/ci.yml?branch=main)](https://github.com/HadrienG2/hwlocality/actions?query=workflow%3A%22Continuous+Integration%22)
 [![CII Best Practices Summary](https://img.shields.io/cii/summary/7876)](https://www.bestpractices.dev/en/projects/7876)
 ![Requires rustc
-1.84.0+](https://img.shields.io/badge/rustc-1.84.0+-lightgray.svg)
+1.85.0+](https://img.shields.io/badge/rustc-1.85.0+-lightgray.svg)
 
 This crate contains the low-level unsafe Rust -> C FFI bindings to
 [hwloc](http://www.open-mpi.org/projects/hwloc), that are used to implement the

--- a/hwlocality-sys/build.rs
+++ b/hwlocality-sys/build.rs
@@ -286,9 +286,13 @@ fn install_hwloc_autotools(source_path: impl AsRef<Path>) {
     // Combine it with any pre-existing PKG_CONFIG_PATH
     match env::var("PKG_CONFIG_PATH") {
         Ok(old_path) if !old_path.is_empty() => {
-            env::set_var("PKG_CONFIG_PATH", format!("{new_path}:{old_path}"))
+            // SAFETY: Safe to call in a single-threaded program
+            unsafe { env::set_var("PKG_CONFIG_PATH", format!("{new_path}:{old_path}")) }
         }
-        Ok(_) | Err(env::VarError::NotPresent) => env::set_var("PKG_CONFIG_PATH", new_path),
+        Ok(_) | Err(env::VarError::NotPresent) => {
+            // SAFETY: Safe to call in a single-threaded program
+            unsafe { env::set_var("PKG_CONFIG_PATH", new_path) }
+        }
         Err(other_err) => panic!("Failed to check PKG_CONFIG_PATH: {other_err}"),
     }
 

--- a/hwlocality-sys/build.rs
+++ b/hwlocality-sys/build.rs
@@ -131,7 +131,11 @@ fn setup_vendored_hwloc(min_required_version: &str) {
 /// Decode a hexadecimal digest into a stream of bytes
 #[cfg(feature = "vendored")]
 fn hex(hex: &'static str) -> Box<[u8]> {
-    assert_eq!(hex.len() % 2, 0, "Digest string {hex:?} should contain full bytes, i.e. pairs of hex digits, but it contains an odd number of bytes");
+    assert_eq!(
+        hex.len() % 2,
+        0,
+        "Digest string {hex:?} should contain full bytes, i.e. pairs of hex digits, but it contains an odd number of bytes"
+    );
     hex.as_bytes()
         .chunks_exact(2)
         .map(|hexdigit_pair| {

--- a/hwlocality-sys/src/lib.rs
+++ b/hwlocality-sys/src/lib.rs
@@ -3364,7 +3364,7 @@ macro_rules! extern_c_block {
             #[cfg(feature = "hwloc-2_4_0")]
             #[must_use]
             pub fn hwloc_cpukinds_get_nr(topology: hwloc_const_topology_t, flags: c_ulong)
-                -> c_int;
+            -> c_int;
             #[cfg(feature = "hwloc-2_4_0")]
             #[must_use]
             pub fn hwloc_cpukinds_get_by_cpuset(

--- a/hwlocality-sys/src/lib.rs
+++ b/hwlocality-sys/src/lib.rs
@@ -2375,7 +2375,7 @@ pub use memory_attributes::*;
 macro_rules! extern_c_block {
     ($link_name:literal) => {
         #[link(name = $link_name)]
-        extern "C" {
+        unsafe extern "C" {
             // === API versioning: https://hwloc.readthedocs.io/en/stable/group__hwlocality__api__version.html
 
             /// Indicate at runtime which hwloc API version was used at build time

--- a/src/bitmap/cow.rs
+++ b/src/bitmap/cow.rs
@@ -33,7 +33,7 @@ pub enum BitmapCow<'target, Target: OwnedBitmap> {
     Owned(Target),
 }
 
-impl<'target, Target: OwnedBitmap> BitmapCow<'target, Target> {
+impl<Target: OwnedBitmap> BitmapCow<'_, Target> {
     /// Extracts the owned bitmap
     ///
     /// Clones the bitmap if it is not already owned.
@@ -45,7 +45,7 @@ impl<'target, Target: OwnedBitmap> BitmapCow<'target, Target> {
     }
 }
 
-impl<'target, Target: OwnedBitmap> AsRef<Target> for BitmapCow<'target, Target> {
+impl<Target: OwnedBitmap> AsRef<Target> for BitmapCow<'_, Target> {
     fn as_ref(&self) -> &Target {
         match self {
             Self::Borrowed(b) => b.as_ref(),
@@ -94,7 +94,7 @@ impl<'target, Target: OwnedBitmap> From<BitmapRef<'target, Target>> for BitmapCo
     }
 }
 
-impl<'target, Target: OwnedBitmap + Hash> Hash for BitmapCow<'target, Target> {
+impl<Target: OwnedBitmap + Hash> Hash for BitmapCow<'_, Target> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.as_ref().hash(state)
     }

--- a/src/bitmap/newtypes.rs
+++ b/src/bitmap/newtypes.rs
@@ -2,7 +2,7 @@
 
 #[cfg(doc)]
 use super::BitmapRef;
-use super::{hwloc_bitmap_s, Bitmap, BitmapIndex};
+use super::{Bitmap, BitmapIndex, hwloc_bitmap_s};
 use crate::Sealed;
 #[cfg(doc)]
 use crate::{cpu::cpuset::CpuSet, memory::nodeset::NodeSet};

--- a/src/bitmap/reference.rs
+++ b/src/bitmap/reference.rs
@@ -713,14 +713,18 @@ pub(super) mod tests {
         prop_assert_eq!(format!("{:p}", bitmap.0), format!("{bitmap_ref:p}"));
 
         bitmap::allow_infinite_iteration(|| {
-            prop_assert!(bitmap
-                .iter_set()
-                .take(INFINITE_EXPLORE_ITERS)
-                .eq(bitmap_ref.into_iter().take(INFINITE_EXPLORE_ITERS)));
-            prop_assert!(bitmap
-                .iter_set()
-                .take(INFINITE_EXPLORE_ITERS)
-                .eq((&bitmap_ref).into_iter().take(INFINITE_EXPLORE_ITERS)));
+            prop_assert!(
+                bitmap
+                    .iter_set()
+                    .take(INFINITE_EXPLORE_ITERS)
+                    .eq(bitmap_ref.into_iter().take(INFINITE_EXPLORE_ITERS))
+            );
+            prop_assert!(
+                bitmap
+                    .iter_set()
+                    .take(INFINITE_EXPLORE_ITERS)
+                    .eq((&bitmap_ref).into_iter().take(INFINITE_EXPLORE_ITERS))
+            );
             Ok(())
         })?;
 

--- a/src/cpu/binding.rs
+++ b/src/cpu/binding.rs
@@ -7,21 +7,21 @@
 //! struct](../../topology/struct.Topology.html#cpu-binding). The module itself
 //! only hosts type definitions that are related to this functionality.
 
-#[cfg(doc)]
-use crate::{bitmap::Bitmap, object::types::ObjectType, topology::support::CpuBindingSupport};
 use crate::{
+    ProcessId, ThreadId,
     cpu::cpuset::CpuSet,
     errors::{self, FlagsError, HybridError, RawHwlocError},
     topology::Topology,
-    ProcessId, ThreadId,
 };
+#[cfg(doc)]
+use crate::{bitmap::Bitmap, object::types::ObjectType, topology::support::CpuBindingSupport};
 use bitflags::bitflags;
 use derive_more::Display;
 use errno::Errno;
 use hwlocality_sys::{
+    HWLOC_CPUBIND_NOMEMBIND, HWLOC_CPUBIND_PROCESS, HWLOC_CPUBIND_STRICT, HWLOC_CPUBIND_THREAD,
     hwloc_const_cpuset_t, hwloc_const_topology_t, hwloc_cpubind_flags_t, hwloc_cpuset_t,
-    hwloc_pid_t, HWLOC_CPUBIND_NOMEMBIND, HWLOC_CPUBIND_PROCESS, HWLOC_CPUBIND_STRICT,
-    HWLOC_CPUBIND_THREAD,
+    hwloc_pid_t,
 };
 use libc::{ENOSYS, EXDEV};
 #[cfg(any(test, feature = "proptest"))]

--- a/src/cpu/cpuset.rs
+++ b/src/cpu/cpuset.rs
@@ -14,9 +14,9 @@ use crate::{
     impl_bitmap_newtype,
     memory::nodeset::NodeSet,
     object::{
+        TopologyObject,
         depth::{Depth, NormalDepth},
         types::ObjectType,
-        TopologyObject,
     },
     topology::Topology,
 };

--- a/src/cpu/kind.rs
+++ b/src/cpu/kind.rs
@@ -19,7 +19,7 @@ use crate::{
     errors::{self},
     ffi::{int, string::LibcString, transparent::AsNewtype},
     info::TextualInfo,
-    topology::{editor::TopologyEditor, Topology},
+    topology::{Topology, editor::TopologyEditor},
 };
 use derive_more::Display;
 use hwlocality_sys::hwloc_info_s;

--- a/src/ffi/int.rs
+++ b/src/ffi/int.rs
@@ -881,11 +881,7 @@ impl PositiveInt {
     /// ```
     #[allow(clippy::if_then_some_else_none)]
     pub const fn checked_neg(self) -> Option<Self> {
-        if self.0 == 0 {
-            Some(Self(0))
-        } else {
-            None
-        }
+        if self.0 == 0 { Some(Self(0)) } else { None }
     }
 
     /// Checked shift left. Computes `self << rhs`, returning `None` if `rhs` is
@@ -2979,7 +2975,9 @@ macro_rules! shl_with_int {
     )* };
 }
 //
-shl_with_int!(i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize);
+shl_with_int!(
+    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize
+);
 
 impl<Rhs> ShlAssign<Rhs> for PositiveInt
 where
@@ -3076,7 +3074,9 @@ macro_rules! shr_with_int {
     )* };
 }
 //
-shr_with_int!(i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize);
+shr_with_int!(
+    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize
+);
 
 impl<Rhs> ShrAssign<Rhs> for PositiveInt
 where

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -222,8 +222,8 @@ mod tests {
             i32::try_from(original_bytes.len() - 1).unwrap()
         }
 
-        // SAFETY: snprintf closure is indeed an snprintf-like function
         assert!(
+            // SAFETY: snprintf closure is indeed an snprintf-like function
             unsafe { call_snprintf(|buf, len| snprintf(buf, len)) }
                 .iter()
                 .copied()

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -160,8 +160,9 @@ mod tests {
         assert_eq!(unsafe { deref_ptr(&ptr::null::<u16>()) }, None);
         // SAFETY: Safe to call on a null pointer
         assert_eq!(unsafe { deref_ptr_mut(&ptr::null_mut::<u16>()) }, None);
+        let mut null_mut = ptr::null_mut::<u16>();
         // SAFETY: Safe to call on a null pointer
-        assert_eq!(unsafe { deref_mut_ptr(&mut ptr::null_mut::<u16>()) }, None);
+        assert_eq!(unsafe { deref_mut_ptr(&mut null_mut) }, None);
 
         let mut x = 42;
         {

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -13,7 +13,7 @@ pub(crate) mod unknown;
 #[cfg(test)]
 use similar_asserts::assert_eq;
 use std::{
-    ffi::{c_char, CStr},
+    ffi::{CStr, c_char},
     fmt, ptr,
 };
 
@@ -223,10 +223,12 @@ mod tests {
         }
 
         // SAFETY: snprintf closure is indeed an snprintf-like function
-        assert!(unsafe { call_snprintf(|buf, len| snprintf(buf, len)) }
-            .iter()
-            .copied()
-            .eq(ORIGINAL.bytes().map(|b| c_char::try_from(b).unwrap())));
+        assert!(
+            unsafe { call_snprintf(|buf, len| snprintf(buf, len)) }
+                .iter()
+                .copied()
+                .eq(ORIGINAL.bytes().map(|b| c_char::try_from(b).unwrap()))
+        );
 
         struct Harness;
         //

--- a/src/interop/windows.rs
+++ b/src/interop/windows.rs
@@ -59,10 +59,10 @@ impl Topology {
         &self,
     ) -> Result<
         impl DoubleEndedIterator<Item = Result<CpuSet, RawHwlocError>>
-            + Clone
-            + ExactSizeIterator
-            + FusedIterator
-            + '_,
+        + Clone
+        + ExactSizeIterator
+        + FusedIterator
+        + '_,
         RawHwlocError,
     > {
         Ok(

--- a/src/memory/attribute.rs
+++ b/src/memory/attribute.rs
@@ -26,8 +26,8 @@ use crate::{
         string::LibcString,
         transparent::{AsInner, AsNewtype},
     },
-    object::{types::ObjectType, TopologyObject, TopologyObjectID},
-    topology::{editor::TopologyEditor, Topology},
+    object::{TopologyObject, TopologyObjectID, types::ObjectType},
+    topology::{Topology, editor::TopologyEditor},
 };
 use bitflags::bitflags;
 use derive_more::{Display, From};
@@ -35,12 +35,13 @@ use errno::Errno;
 #[cfg(feature = "hwloc-2_12_1")]
 use hwlocality_sys::HWLOC_LOCAL_NUMANODE_FLAG_INTERSECT_LOCALITY;
 use hwlocality_sys::{
-    hwloc_const_topology_t, hwloc_local_numanode_flag_e, hwloc_location, hwloc_location_u,
-    hwloc_memattr_flag_e, hwloc_memattr_id_t, hwloc_obj, HWLOC_LOCAL_NUMANODE_FLAG_ALL,
-    HWLOC_LOCAL_NUMANODE_FLAG_LARGER_LOCALITY, HWLOC_LOCAL_NUMANODE_FLAG_SMALLER_LOCALITY,
-    HWLOC_LOCATION_TYPE_CPUSET, HWLOC_LOCATION_TYPE_OBJECT, HWLOC_MEMATTR_FLAG_HIGHER_FIRST,
-    HWLOC_MEMATTR_FLAG_LOWER_FIRST, HWLOC_MEMATTR_FLAG_NEED_INITIATOR, HWLOC_MEMATTR_ID_BANDWIDTH,
-    HWLOC_MEMATTR_ID_CAPACITY, HWLOC_MEMATTR_ID_LATENCY, HWLOC_MEMATTR_ID_LOCALITY,
+    HWLOC_LOCAL_NUMANODE_FLAG_ALL, HWLOC_LOCAL_NUMANODE_FLAG_LARGER_LOCALITY,
+    HWLOC_LOCAL_NUMANODE_FLAG_SMALLER_LOCALITY, HWLOC_LOCATION_TYPE_CPUSET,
+    HWLOC_LOCATION_TYPE_OBJECT, HWLOC_MEMATTR_FLAG_HIGHER_FIRST, HWLOC_MEMATTR_FLAG_LOWER_FIRST,
+    HWLOC_MEMATTR_FLAG_NEED_INITIATOR, HWLOC_MEMATTR_ID_BANDWIDTH, HWLOC_MEMATTR_ID_CAPACITY,
+    HWLOC_MEMATTR_ID_LATENCY, HWLOC_MEMATTR_ID_LOCALITY, hwloc_const_topology_t,
+    hwloc_local_numanode_flag_e, hwloc_location, hwloc_location_u, hwloc_memattr_flag_e,
+    hwloc_memattr_id_t, hwloc_obj,
 };
 #[cfg(feature = "hwloc-2_8_0")]
 use hwlocality_sys::{
@@ -53,7 +54,7 @@ use libc::{EBUSY, EINVAL, ENOENT};
 use similar_asserts::assert_eq;
 use std::{
     collections::{HashMap, HashSet},
-    ffi::{c_int, c_uint, c_ulong, CStr},
+    ffi::{CStr, c_int, c_uint, c_ulong},
     fmt::{self, Debug},
     hash::Hash,
     mem::MaybeUninit,
@@ -1087,7 +1088,9 @@ pub enum ValueInputError {
     /// Some provided initiator have the `Object` type, which the currently
     /// enabled set of hwlocs version does not properly support (need hwloc
     /// v3.0.0 or newer)
-    #[error("some initiators are Objects, but you need to request hwloc v3+ via feature hwloc-3_0_0 for that")]
+    #[error(
+        "some initiators are Objects, but you need to request hwloc v3+ via feature hwloc-3_0_0 for that"
+    )]
     ObjectInitiator,
 
     /// Some provided targets are [`TopologyObject`]s that do not belong to
@@ -2715,9 +2718,11 @@ mod tests {
             ) = (expected_best_targets, best_target)
             {
                 assert_eq!(best_value, expected_best_value);
-                assert!(expected_best_targets
-                    .into_iter()
-                    .any(|target_id| { best_target.global_persistent_index() == target_id }));
+                assert!(
+                    expected_best_targets
+                        .into_iter()
+                        .any(|target_id| { best_target.global_persistent_index() == target_id })
+                );
             }
         }
     }
@@ -2749,10 +2754,12 @@ mod tests {
         ) = (expected_best_targets, best_target)
         {
             assert_eq!(best_value, expected_best_value);
-            assert!(expected_best_targets
-                .into_iter()
-                .any(|target| target.global_persistent_index()
-                    == best_target.global_persistent_index()));
+            assert!(
+                expected_best_targets
+                    .into_iter()
+                    .any(|target| target.global_persistent_index()
+                        == best_target.global_persistent_index())
+            );
         }
     }
 
@@ -2786,8 +2793,8 @@ mod tests {
     /// Pick a memory attribute and a target that has a chance of being correct
     /// for this attribute, but may be a random object possibly coming from
     /// another topology.
-    fn memory_attribute_and_target(
-    ) -> impl Strategy<Value = (MemoryAttribute<'static>, &'static TopologyObject)> {
+    fn memory_attribute_and_target()
+    -> impl Strategy<Value = (MemoryAttribute<'static>, &'static TopologyObject)> {
         memory_attribute().prop_flat_map(|attr| {
             let targets = attr.targets(None).unwrap().0;
             let target = if targets.is_empty() {
@@ -2974,8 +2981,8 @@ mod tests {
     /// Given a memory attribute, pick an initiator that has a chance of being
     /// correct for this attribute, but may be a random object possibly coming
     /// from another topology.
-    fn memory_attribute_and_initiator(
-    ) -> impl Strategy<Value = (MemoryAttribute<'static>, Option<Initiator<'static>>)> {
+    fn memory_attribute_and_initiator()
+    -> impl Strategy<Value = (MemoryAttribute<'static>, Option<Initiator<'static>>)> {
         memory_attribute_target_initiator().prop_map(|(attr, _target, initiator)| (attr, initiator))
     }
 
@@ -3731,9 +3738,11 @@ mod tests {
                 prop_assert_eq!(new_attr.value(None, target), Ok(Some(*expected_value)));
                 let target_id = target.global_persistent_index();
                 id_to_target.entry(target_id).or_insert(target);
-                prop_assert!(target_id_to_value
-                    .insert(target_id, *expected_value)
-                    .is_none());
+                prop_assert!(
+                    target_id_to_value
+                        .insert(target_id, *expected_value)
+                        .is_none()
+                );
             }
 
             // There is no initiator, so there's a target-to-value mapping

--- a/src/memory/attribute.rs
+++ b/src/memory/attribute.rs
@@ -2340,10 +2340,8 @@ impl NUMAInitiator<'_> {
         topology: &Topology,
     ) -> Result<(Option<hwloc_location>, LocalNUMANodeFlags), ForeignInitiatorError> {
         match self {
-            Self::Local {
-                initiator,
-                mut flags,
-            } => {
+            Self::Local { initiator, flags } => {
+                let mut flags = *flags;
                 flags.remove(LocalNUMANodeFlags::ALL);
                 // SAFETY: Per function precondition
                 Ok((Some(unsafe { initiator.as_checked_raw(topology)? }), flags))
@@ -3269,7 +3267,7 @@ mod tests {
     fn initiators(
         flags: MemoryAttributeFlags,
         targets_and_values: &TargetsAndValues,
-    ) -> impl Strategy<Value = Initiators> {
+    ) -> impl Strategy<Value = Initiators> + use<> {
         // Query basic topology properties
         let topology = Topology::test_instance();
         let num_objects = topology.objects().count();

--- a/src/memory/binding.rs
+++ b/src/memory/binding.rs
@@ -8,12 +8,12 @@
 //! itself only hosts type definitions that are related to this functionality.
 
 use crate::{
+    ProcessId,
     bitmap::{Bitmap, BitmapKind, SpecializedBitmap, SpecializedBitmapRef},
     errors::{self, FlagsError, HybridError, RawHwlocError},
     ffi::unknown::UnknownVariant,
     memory::nodeset::NodeSet,
     topology::Topology,
-    ProcessId,
 };
 #[cfg(doc)]
 use crate::{cpu::cpuset::CpuSet, topology::support::MemoryBindingSupport};
@@ -23,11 +23,11 @@ use errno::Errno;
 #[cfg(feature = "hwloc-2_11_0")]
 use hwlocality_sys::HWLOC_MEMBIND_WEIGHTED_INTERLEAVE;
 use hwlocality_sys::{
+    HWLOC_MEMBIND_BIND, HWLOC_MEMBIND_BYNODESET, HWLOC_MEMBIND_DEFAULT, HWLOC_MEMBIND_FIRSTTOUCH,
+    HWLOC_MEMBIND_INTERLEAVE, HWLOC_MEMBIND_MIGRATE, HWLOC_MEMBIND_MIXED, HWLOC_MEMBIND_NEXTTOUCH,
+    HWLOC_MEMBIND_NOCPUBIND, HWLOC_MEMBIND_PROCESS, HWLOC_MEMBIND_STRICT, HWLOC_MEMBIND_THREAD,
     hwloc_bitmap_t, hwloc_const_bitmap_t, hwloc_const_topology_t, hwloc_membind_flags_t,
-    hwloc_membind_policy_t, hwloc_pid_t, HWLOC_MEMBIND_BIND, HWLOC_MEMBIND_BYNODESET,
-    HWLOC_MEMBIND_DEFAULT, HWLOC_MEMBIND_FIRSTTOUCH, HWLOC_MEMBIND_INTERLEAVE,
-    HWLOC_MEMBIND_MIGRATE, HWLOC_MEMBIND_MIXED, HWLOC_MEMBIND_NEXTTOUCH, HWLOC_MEMBIND_NOCPUBIND,
-    HWLOC_MEMBIND_PROCESS, HWLOC_MEMBIND_STRICT, HWLOC_MEMBIND_THREAD,
+    hwloc_membind_policy_t, hwloc_pid_t,
 };
 use libc::{ENOMEM, ENOSYS, EXDEV};
 #[allow(unused)]

--- a/src/object/attributes/bridge.rs
+++ b/src/object/attributes/bridge.rs
@@ -15,7 +15,7 @@ use crate::{
 #[cfg(any(test, feature = "proptest"))]
 use hwlocality_sys::hwloc_obj_bridge_type_t;
 use hwlocality_sys::{
-    hwloc_bridge_attr_s, RawDownstreamAttributes, RawDownstreamPCIAttributes, RawUpstreamAttributes,
+    RawDownstreamAttributes, RawDownstreamPCIAttributes, RawUpstreamAttributes, hwloc_bridge_attr_s,
 };
 #[cfg(any(test, feature = "proptest"))]
 use proptest::prelude::*;
@@ -270,12 +270,12 @@ impl<'object> DownstreamAttributes<'object> {
 pub(super) mod tests {
     use super::*;
     use crate::object::{
-        attributes::{
-            pci::tests::{check_any_pci, check_valid_pci, pci_attributes},
-            tests::{object_pair, parent_child, ObjectsWithAttrs},
-            ObjectAttributes,
-        },
         ObjectType,
+        attributes::{
+            ObjectAttributes,
+            pci::tests::{check_any_pci, check_valid_pci, pci_attributes},
+            tests::{ObjectsWithAttrs, object_pair, parent_child},
+        },
     };
     use crate::{ffi::transparent::AsInner, object::TopologyObject, tests::assert_panics};
     use hwlocality_sys::{hwloc_obj_attr_u, hwloc_pcidev_attr_s};

--- a/src/object/attributes/bridge.rs
+++ b/src/object/attributes/bridge.rs
@@ -410,9 +410,10 @@ pub(super) mod tests {
             Some(UpstreamAttributes::PCI(pci)) => {
                 prop_assert_eq!(upstream_type, BridgeType::PCI);
                 let actual_ptr: *const hwloc_pcidev_attr_s = pci.as_inner();
-                // SAFETY: This unsafe block will be removed on next MSRV bump
-                //         as this pattern is not considered unsafe anymore,
-                //         though it was considered unsafe by Rust 1.84.
+                // SAFETY: This unsafe block will be removed on a future MSRV
+                //         bump as this pattern is not considered unsafe
+                //         anymore, but was considered unsafe by Rust 1.85 which
+                //         is our current MSRV.
                 #[allow(unused_unsafe)]
                 let expected_ptr = unsafe { &raw const attr.0.upstream.pci };
                 prop_assert_eq!(actual_ptr, expected_ptr);
@@ -436,9 +437,10 @@ pub(super) mod tests {
                 match attr.downstream_attributes() {
                     Some(DownstreamAttributes::PCI(downstream)) => {
                         let actual_ptr: *const RawDownstreamPCIAttributes = downstream.as_inner();
-                        // SAFETY: This unsafe block will be removed on next MSRV bump
-                        //         as this pattern is not considered unsafe anymore,
-                        //         though it was considered unsafe by Rust 1.84.
+                        // SAFETY: This unsafe block will be removed on a future
+                        //         MSRV bump as this pattern is not considered
+                        //         unsafe anymore, but was considered unsafe by
+                        //         Rust 1.85 which is our current MSRV.
                         #[allow(unused_unsafe)]
                         let expected_ptr = unsafe { &raw const attr.0.downstream.pci };
                         prop_assert_eq!(actual_ptr, expected_ptr);

--- a/src/object/attributes/cache.rs
+++ b/src/object/attributes/cache.rs
@@ -218,13 +218,13 @@ pub(super) mod tests {
     use crate::{
         ffi::transparent::AsInner,
         object::{
+            TopologyObject,
             attributes::{
-                tests::{object_pair, ObjectsWithAttrs},
                 ObjectAttributes,
+                tests::{ObjectsWithAttrs, object_pair},
             },
             depth::NormalDepth,
             types::ObjectType,
-            TopologyObject,
         },
         tests::assert_panics,
     };

--- a/src/object/attributes/group.rs
+++ b/src/object/attributes/group.rs
@@ -145,13 +145,13 @@ pub(super) mod tests {
     use crate::{
         ffi::transparent::AsInner,
         object::{
+            TopologyObject,
             attributes::{
-                tests::{object_pair, ObjectsWithAttrs},
                 ObjectAttributes,
+                tests::{ObjectsWithAttrs, object_pair},
             },
             depth::NormalDepth,
             types::ObjectType,
-            TopologyObject,
         },
     };
     use hwlocality_sys::hwloc_obj_attr_u;

--- a/src/object/attributes/mod.rs
+++ b/src/object/attributes/mod.rs
@@ -107,8 +107,8 @@ mod tests {
     };
     use crate::{
         object::{
-            types::{BridgeType, CacheType},
             TopologyObject,
+            types::{BridgeType, CacheType},
         },
         topology::Topology,
     };

--- a/src/object/attributes/numa.rs
+++ b/src/object/attributes/numa.rs
@@ -190,12 +190,12 @@ pub(super) mod tests {
     use crate::{
         ffi::transparent::AsInner,
         object::{
+            TopologyObject,
             attributes::{
-                tests::{object_pair, ObjectsWithAttrs},
                 ObjectAttributes,
+                tests::{ObjectsWithAttrs, object_pair},
             },
             types::ObjectType,
-            TopologyObject,
         },
         tests::assert_panics,
     };

--- a/src/object/attributes/pci.rs
+++ b/src/object/attributes/pci.rs
@@ -166,12 +166,12 @@ pub(super) mod tests {
     use crate::{
         ffi::transparent::AsInner,
         object::{
+            TopologyObject,
             attributes::{
-                tests::{object_pair, parent_child, ObjectsWithAttrs},
                 ObjectAttributes,
+                tests::{ObjectsWithAttrs, object_pair, parent_child},
             },
             types::ObjectType,
-            TopologyObject,
         },
     };
     use hwlocality_sys::hwloc_obj_attr_u;

--- a/src/object/depth.rs
+++ b/src/object/depth.rs
@@ -26,13 +26,13 @@
 
 use crate::ffi::{int::PositiveInt, unknown::UnknownVariant};
 #[cfg(doc)]
-use crate::object::{types::ObjectType, TopologyObject};
+use crate::object::{TopologyObject, types::ObjectType};
 #[cfg(feature = "hwloc-2_1_0")]
 use hwlocality_sys::HWLOC_TYPE_DEPTH_MEMCACHE;
 use hwlocality_sys::{
-    hwloc_get_type_depth_e, HWLOC_TYPE_DEPTH_BRIDGE, HWLOC_TYPE_DEPTH_MISC,
-    HWLOC_TYPE_DEPTH_MULTIPLE, HWLOC_TYPE_DEPTH_NUMANODE, HWLOC_TYPE_DEPTH_OS_DEVICE,
-    HWLOC_TYPE_DEPTH_PCI_DEVICE, HWLOC_TYPE_DEPTH_UNKNOWN,
+    HWLOC_TYPE_DEPTH_BRIDGE, HWLOC_TYPE_DEPTH_MISC, HWLOC_TYPE_DEPTH_MULTIPLE,
+    HWLOC_TYPE_DEPTH_NUMANODE, HWLOC_TYPE_DEPTH_OS_DEVICE, HWLOC_TYPE_DEPTH_PCI_DEVICE,
+    HWLOC_TYPE_DEPTH_UNKNOWN, hwloc_get_type_depth_e,
 };
 #[cfg(any(test, feature = "proptest"))]
 use proptest::prelude::*;

--- a/src/object/distance.rs
+++ b/src/object/distance.rs
@@ -23,7 +23,7 @@ use crate::{errors::FlagsError, ffi::unknown::UnknownVariant};
 use crate::{
     errors::{self, ForeignObjectError, RawHwlocError},
     ffi::{self, int, transparent::TransparentNewtype},
-    object::{depth::Depth, types::ObjectType, TopologyObject, TopologyObjectID},
+    object::{TopologyObject, TopologyObjectID, depth::Depth, types::ObjectType},
     topology::Topology,
 };
 #[cfg(feature = "hwloc-2_1_0")]
@@ -34,17 +34,17 @@ use crate::{
 use bitflags::bitflags;
 #[cfg(feature = "hwloc-2_1_0")]
 use hwlocality_sys::HWLOC_DISTANCES_KIND_HETEROGENEOUS_TYPES;
-use hwlocality_sys::{
-    hwloc_const_topology_t, hwloc_distances_kind_e, hwloc_distances_s, hwloc_obj, hwloc_topology,
-    HWLOC_DISTANCES_KIND_FROM_OS, HWLOC_DISTANCES_KIND_FROM_USER,
-    HWLOC_DISTANCES_KIND_MEANS_BANDWIDTH, HWLOC_DISTANCES_KIND_MEANS_LATENCY,
-};
 #[cfg(feature = "hwloc-2_5_0")]
 use hwlocality_sys::{
-    hwloc_distances_add_flag_e, hwloc_distances_transform_e, HWLOC_DISTANCES_ADD_FLAG_GROUP,
-    HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE, HWLOC_DISTANCES_TRANSFORM_LINKS,
-    HWLOC_DISTANCES_TRANSFORM_MERGE_SWITCH_PORTS, HWLOC_DISTANCES_TRANSFORM_REMOVE_NULL,
-    HWLOC_DISTANCES_TRANSFORM_TRANSITIVE_CLOSURE,
+    HWLOC_DISTANCES_ADD_FLAG_GROUP, HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE,
+    HWLOC_DISTANCES_TRANSFORM_LINKS, HWLOC_DISTANCES_TRANSFORM_MERGE_SWITCH_PORTS,
+    HWLOC_DISTANCES_TRANSFORM_REMOVE_NULL, HWLOC_DISTANCES_TRANSFORM_TRANSITIVE_CLOSURE,
+    hwloc_distances_add_flag_e, hwloc_distances_transform_e,
+};
+use hwlocality_sys::{
+    HWLOC_DISTANCES_KIND_FROM_OS, HWLOC_DISTANCES_KIND_FROM_USER,
+    HWLOC_DISTANCES_KIND_MEANS_BANDWIDTH, HWLOC_DISTANCES_KIND_MEANS_LATENCY,
+    hwloc_const_topology_t, hwloc_distances_kind_e, hwloc_distances_s, hwloc_obj, hwloc_topology,
 };
 #[allow(unused)]
 #[cfg(test)]
@@ -968,9 +968,9 @@ impl<'topology> Distances<'topology> {
     pub fn objects(
         &self,
     ) -> impl DoubleEndedIterator<Item = Option<&TopologyObject>>
-           + Clone
-           + ExactSizeIterator
-           + FusedIterator {
+    + Clone
+    + ExactSizeIterator
+    + FusedIterator {
         // SAFETY: - inner is assumed valid as a type invariant, thus objs &
         //           num_objects() are trusted to be consistent, objs is assumed
         //           unaliased and bound to the lifetime of self.topology,
@@ -1161,10 +1161,10 @@ impl<'topology> Distances<'topology> {
     pub fn enumerate_distances(
         &self,
     ) -> impl DoubleEndedIterator<Item = ((usize, usize), u64)>
-           + Clone
-           + ExactSizeIterator
-           + FusedIterator
-           + '_ {
+    + Clone
+    + ExactSizeIterator
+    + FusedIterator
+    + '_ {
         let num_objects = self.num_objects();
         self.distances()
             .iter()

--- a/src/object/hierarchy.rs
+++ b/src/object/hierarchy.rs
@@ -1,10 +1,10 @@
 //! Queries against the depth- and type-based hierarchy of objects
 
 use super::{
+    TopologyObject,
     attributes::ObjectAttributes,
     depth::{Depth, NormalDepth, TypeToDepthError},
     types::{CacheType, ObjectType},
-    TopologyObject,
 };
 use crate::{
     ffi::{int, transparent::AsNewtype, unknown::UnknownVariant},

--- a/src/object/lists.rs
+++ b/src/object/lists.rs
@@ -1,8 +1,8 @@
 //! Full lists of objects contained within the topology
 
 use super::{
-    depth::{Depth, NormalDepth},
     TopologyObject,
+    depth::{Depth, NormalDepth},
 };
 use crate::topology::Topology;
 #[allow(unused)]
@@ -116,15 +116,19 @@ pub(crate) mod tests {
         let keys = object_ids_from_set(&objects);
 
         let normal_objects = checked_object_set(topology.normal_objects());
-        assert!(normal_objects
-            .values()
-            .all(|obj| obj.object_type().is_normal()));
+        assert!(
+            normal_objects
+                .values()
+                .all(|obj| obj.object_type().is_normal())
+        );
         let normal_keys = object_ids_from_set(&normal_objects);
 
         let virtual_objects = checked_object_set(topology.virtual_objects());
-        assert!(virtual_objects
-            .values()
-            .all(|obj| !obj.object_type().is_normal()));
+        assert!(
+            virtual_objects
+                .values()
+                .all(|obj| !obj.object_type().is_normal())
+        );
         let virtual_keys = object_ids_from_set(&virtual_objects);
 
         assert_eq!(keys, &normal_keys | &virtual_keys);
@@ -132,9 +136,11 @@ pub(crate) mod tests {
         assert_eq!(virtual_keys, &keys - &normal_keys);
 
         let memory_objects = checked_object_set(topology.memory_objects());
-        assert!(memory_objects
-            .values()
-            .all(|obj| obj.object_type().is_memory()));
+        assert!(
+            memory_objects
+                .values()
+                .all(|obj| obj.object_type().is_memory())
+        );
         let memory_keys = object_ids_from_set(&memory_objects);
 
         let io_objects = checked_object_set(topology.io_objects());
@@ -142,9 +148,11 @@ pub(crate) mod tests {
         let io_keys = object_ids_from_set(&io_objects);
 
         let misc_objects = checked_object_set(topology.objects_with_type(ObjectType::Misc));
-        assert!(misc_objects
-            .values()
-            .all(|obj| obj.object_type() == ObjectType::Misc));
+        assert!(
+            misc_objects
+                .values()
+                .all(|obj| obj.object_type() == ObjectType::Misc)
+        );
         let misc_keys = object_ids_from_set(&misc_objects);
 
         assert_eq!(virtual_keys, &(&memory_keys | &io_keys) | &misc_keys);

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -26,7 +26,7 @@ use self::{
     types::ObjectType,
 };
 #[cfg(doc)]
-use crate::topology::{builder::BuildFlags, support::DiscoverySupport, Topology};
+use crate::topology::{Topology, builder::BuildFlags, support::DiscoverySupport};
 use crate::{
     bitmap::BitmapRef,
     cpu::cpuset::CpuSet,
@@ -42,7 +42,7 @@ use crate::{
     errors::{self, HybridError, NulError},
     ffi::string::LibcString,
 };
-use hwlocality_sys::{hwloc_obj, HWLOC_UNKNOWN_INDEX};
+use hwlocality_sys::{HWLOC_UNKNOWN_INDEX, hwloc_obj};
 #[allow(unused)]
 #[cfg(test)]
 use similar_asserts::assert_eq;
@@ -1223,14 +1223,18 @@ pub(crate) mod tests {
             prop_assert!(parent.object_type().has_sets());
             prop_assert!(parent.cpuset().unwrap().includes(obj.cpuset().unwrap()));
             prop_assert!(parent.nodeset().unwrap().includes(obj.nodeset().unwrap()));
-            prop_assert!(parent
-                .complete_cpuset()
-                .unwrap()
-                .includes(obj.complete_cpuset().unwrap()));
-            prop_assert!(parent
-                .complete_nodeset()
-                .unwrap()
-                .includes(obj.complete_nodeset().unwrap()));
+            prop_assert!(
+                parent
+                    .complete_cpuset()
+                    .unwrap()
+                    .includes(obj.complete_cpuset().unwrap())
+            );
+            prop_assert!(
+                parent
+                    .complete_nodeset()
+                    .unwrap()
+                    .includes(obj.complete_nodeset().unwrap())
+            );
         }
 
         Ok(())
@@ -1320,10 +1324,11 @@ pub(crate) mod tests {
         prop_assert_eq!(cousin.depth(), obj.depth());
         if obj.object_type().has_sets() {
             prop_assert!(!obj.cpuset().unwrap().intersects(cousin.cpuset().unwrap()));
-            prop_assert!(!obj
-                .complete_cpuset()
-                .unwrap()
-                .intersects(cousin.complete_cpuset().unwrap()));
+            prop_assert!(
+                !obj.complete_cpuset()
+                    .unwrap()
+                    .intersects(cousin.complete_cpuset().unwrap())
+            );
         }
         Ok(())
     }
@@ -1443,9 +1448,11 @@ pub(crate) mod tests {
         }
 
         // Only normal objects can be symmetric
-        assert!(topology
-            .virtual_objects()
-            .all(|obj| !obj.is_symmetric_subtree()));
+        assert!(
+            topology
+                .virtual_objects()
+                .all(|obj| !obj.is_symmetric_subtree())
+        );
     }
 
     /// Check that [`TopologyObject::total_memory()`] is correct
@@ -1465,9 +1472,11 @@ pub(crate) mod tests {
             };
             let gp_index = numa.global_persistent_index();
             let local_memory = attrs.local_memory().map_or(0, u64::from);
-            assert!(expected_total_memory
-                .insert(gp_index, local_memory)
-                .is_none());
+            assert!(
+                expected_total_memory
+                    .insert(gp_index, local_memory)
+                    .is_none()
+            );
             assert!(curr_objects.insert(gp_index, numa).is_none());
         }
 
@@ -1543,8 +1552,8 @@ pub(crate) mod tests {
     // --- Querying stuff by cpuset/nodeset ---
 
     /// Pick an object and a related cpuset
-    pub(crate) fn object_and_related_cpuset(
-    ) -> impl Strategy<Value = (&'static TopologyObject, CpuSet)> {
+    pub(crate) fn object_and_related_cpuset()
+    -> impl Strategy<Value = (&'static TopologyObject, CpuSet)> {
         // Separate objects with and without cpusets
         let topology = Topology::test_instance();
         let mut with_cpuset = Vec::new();

--- a/src/object/search/io.rs
+++ b/src/object/search/io.rs
@@ -3,9 +3,9 @@
 use crate::{
     errors::ParameterError,
     object::{
+        TopologyObject,
         attributes::{ObjectAttributes, PCIDomain},
         depth::Depth,
-        TopologyObject,
     },
     topology::Topology,
 };
@@ -200,17 +200,19 @@ mod tests {
                 let Some(ObjectAttributes::PCIDevice(pci)) = device.attributes() else {
                     unreachable!("All PCI devices should have PCI attributes")
                 };
-                assert!(result
-                    .insert(
-                        PCIAddress {
-                            domain: pci.domain(),
-                            bus_id: pci.bus_id(),
-                            bus_device: pci.bus_device(),
-                            function: pci.function(),
-                        },
-                        device
-                    )
-                    .is_none());
+                assert!(
+                    result
+                        .insert(
+                            PCIAddress {
+                                domain: pci.domain(),
+                                bus_id: pci.bus_id(),
+                                bus_device: pci.bus_device(),
+                                function: pci.function(),
+                            },
+                            device
+                        )
+                        .is_none()
+                );
             }
             result
         })

--- a/src/object/search/mod.rs
+++ b/src/object/search/mod.rs
@@ -2,7 +2,7 @@
 
 mod io;
 
-use super::{types::ObjectType, TopologyObject, TopologyObjectID};
+use super::{TopologyObject, TopologyObjectID, types::ObjectType};
 #[cfg(feature = "hwloc-2_5_0")]
 use crate::errors::NulError;
 #[cfg(doc)]
@@ -106,9 +106,9 @@ impl Topology {
         &self,
         ty: ObjectType,
     ) -> impl DoubleEndedIterator<Item = (&TopologyObject, usize)>
-           + Clone
-           + ExactSizeIterator
-           + FusedIterator {
+    + Clone
+    + ExactSizeIterator
+    + FusedIterator {
         self.objects_at_depth(
             self.depth_for_type(ty)
                 .expect("These objects should only appear at a single depth"),
@@ -657,8 +657,8 @@ mod tests {
     /// Generate type-index paths that are mostly valid, but will occasionally
     /// be disordered or invalid, tell what the expected result is if the path
     /// is valid and None otherwise
-    fn type_index_path(
-    ) -> impl Strategy<Value = (Vec<(ObjectType, usize)>, Option<&'static TopologyObject>)> {
+    fn type_index_path()
+    -> impl Strategy<Value = (Vec<(ObjectType, usize)>, Option<&'static TopologyObject>)> {
         // First, have a strategy for generating correct paths
         let topology = Topology::test_instance();
         let valid_path = object_with_cpuset()

--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -12,7 +12,7 @@
 use crate::{
     cpu::cpuset::CpuSet,
     memory::nodeset::NodeSet,
-    object::{depth::Depth, TopologyObject},
+    object::{TopologyObject, depth::Depth},
     topology::{
         builder::{TopologyBuilder, TypeFilter},
         support::DiscoverySupport,
@@ -23,15 +23,15 @@ use derive_more::Display;
 #[cfg(feature = "hwloc-3_0_0")]
 use hwlocality_sys::HWLOC_OBJ_OSDEV_MEMORY;
 use hwlocality_sys::{
-    hwloc_obj_bridge_type_t, hwloc_obj_cache_type_t, hwloc_obj_osdev_type_t, hwloc_obj_type_t,
     HWLOC_OBJ_BRIDGE, HWLOC_OBJ_BRIDGE_HOST, HWLOC_OBJ_BRIDGE_PCI, HWLOC_OBJ_CACHE_DATA,
     HWLOC_OBJ_CACHE_INSTRUCTION, HWLOC_OBJ_CACHE_UNIFIED, HWLOC_OBJ_CORE, HWLOC_OBJ_GROUP,
     HWLOC_OBJ_L1CACHE, HWLOC_OBJ_L1ICACHE, HWLOC_OBJ_L2CACHE, HWLOC_OBJ_L2ICACHE,
     HWLOC_OBJ_L3CACHE, HWLOC_OBJ_L3ICACHE, HWLOC_OBJ_L4CACHE, HWLOC_OBJ_L5CACHE, HWLOC_OBJ_MACHINE,
-    HWLOC_OBJ_MISC, HWLOC_OBJ_NUMANODE, HWLOC_OBJ_OSDEV_COPROC, HWLOC_OBJ_OSDEV_DMA,
-    HWLOC_OBJ_OSDEV_GPU, HWLOC_OBJ_OSDEV_NETWORK, HWLOC_OBJ_OSDEV_OPENFABRICS,
-    HWLOC_OBJ_OSDEV_STORAGE, HWLOC_OBJ_OS_DEVICE, HWLOC_OBJ_PACKAGE, HWLOC_OBJ_PCI_DEVICE,
-    HWLOC_OBJ_PU, HWLOC_TYPE_UNORDERED,
+    HWLOC_OBJ_MISC, HWLOC_OBJ_NUMANODE, HWLOC_OBJ_OS_DEVICE, HWLOC_OBJ_OSDEV_COPROC,
+    HWLOC_OBJ_OSDEV_DMA, HWLOC_OBJ_OSDEV_GPU, HWLOC_OBJ_OSDEV_NETWORK, HWLOC_OBJ_OSDEV_OPENFABRICS,
+    HWLOC_OBJ_OSDEV_STORAGE, HWLOC_OBJ_PACKAGE, HWLOC_OBJ_PCI_DEVICE, HWLOC_OBJ_PU,
+    HWLOC_TYPE_UNORDERED, hwloc_obj_bridge_type_t, hwloc_obj_cache_type_t, hwloc_obj_osdev_type_t,
+    hwloc_obj_type_t,
 };
 #[cfg(feature = "hwloc-2_1_0")]
 use hwlocality_sys::{HWLOC_OBJ_DIE, HWLOC_OBJ_MEMCACHE};

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -20,30 +20,30 @@ use crate::topology::support::DiscoverySupport;
 #[cfg(all(doc, feature = "hwloc-2_3_0"))]
 use crate::topology::support::MiscSupport;
 use crate::{
+    ProcessId,
     errors::{self, FlagsError, HybridError, NulError, RawHwlocError},
     ffi::{string::LibcString, unknown::UnknownVariant},
     object::types::ObjectType,
     path::{self, PathError},
-    ProcessId,
 };
 use bitflags::bitflags;
 use derive_more::From;
 use errno::Errno;
 #[cfg(feature = "hwloc-2_3_0")]
 use hwlocality_sys::HWLOC_TOPOLOGY_FLAG_IMPORT_SUPPORT;
-use hwlocality_sys::{
-    hwloc_pid_t, hwloc_topology, hwloc_topology_flags_e, hwloc_type_filter_e,
-    HWLOC_TOPOLOGY_FLAG_INCLUDE_DISALLOWED, HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM,
-    HWLOC_TOPOLOGY_FLAG_THISSYSTEM_ALLOWED_RESOURCES, HWLOC_TYPE_FILTER_KEEP_ALL,
-    HWLOC_TYPE_FILTER_KEEP_IMPORTANT, HWLOC_TYPE_FILTER_KEEP_NONE,
-    HWLOC_TYPE_FILTER_KEEP_STRUCTURE,
-};
 #[cfg(feature = "hwloc-2_1_0")]
-use hwlocality_sys::{hwloc_topology_components_flag_e, HWLOC_TOPOLOGY_COMPONENTS_FLAG_BLACKLIST};
+use hwlocality_sys::{HWLOC_TOPOLOGY_COMPONENTS_FLAG_BLACKLIST, hwloc_topology_components_flag_e};
 #[cfg(feature = "hwloc-2_5_0")]
 use hwlocality_sys::{
     HWLOC_TOPOLOGY_FLAG_DONT_CHANGE_BINDING, HWLOC_TOPOLOGY_FLAG_RESTRICT_TO_CPUBINDING,
     HWLOC_TOPOLOGY_FLAG_RESTRICT_TO_MEMBINDING,
+};
+use hwlocality_sys::{
+    HWLOC_TOPOLOGY_FLAG_INCLUDE_DISALLOWED, HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM,
+    HWLOC_TOPOLOGY_FLAG_THISSYSTEM_ALLOWED_RESOURCES, HWLOC_TYPE_FILTER_KEEP_ALL,
+    HWLOC_TYPE_FILTER_KEEP_IMPORTANT, HWLOC_TYPE_FILTER_KEEP_NONE,
+    HWLOC_TYPE_FILTER_KEEP_STRUCTURE, hwloc_pid_t, hwloc_topology, hwloc_topology_flags_e,
+    hwloc_type_filter_e,
 };
 #[cfg(feature = "hwloc-2_8_0")]
 use hwlocality_sys::{
@@ -557,15 +557,15 @@ impl TopologyBuilder {
         }
         match (ty, filter) {
             (ObjectType::Group, TypeFilter::KeepAll) => {
-                return Err(TypeFilterError::CantKeepGroup.into())
+                return Err(TypeFilterError::CantKeepGroup.into());
             }
             (ObjectType::Machine | ObjectType::PU | ObjectType::NUMANode, _)
                 if filter != TypeFilter::KeepAll =>
             {
-                return Err(TypeFilterError::CantIgnore(ty).into())
+                return Err(TypeFilterError::CantIgnore(ty).into());
             }
             (_, TypeFilter::KeepStructure) if ty.is_io() || ty == ObjectType::Misc => {
-                return Err(TypeFilterError::StructureIrrelevant.into())
+                return Err(TypeFilterError::StructureIrrelevant.into());
             }
             _ => {}
         }

--- a/src/topology/editor.rs
+++ b/src/topology/editor.rs
@@ -41,16 +41,16 @@ use crate::{
         transparent::{AsInner, AsNewtype},
     },
     memory::nodeset::NodeSet,
-    object::{attributes::GroupAttributes, types::ObjectType, TopologyObject},
-    topology::{builder::TypeFilter, Topology},
+    object::{TopologyObject, attributes::GroupAttributes, types::ObjectType},
+    topology::{Topology, builder::TypeFilter},
 };
 use bitflags::bitflags;
 use errno::Errno;
 use hwlocality_sys::{
-    hwloc_restrict_flags_e, hwloc_topology, HWLOC_ALLOW_FLAG_ALL, HWLOC_ALLOW_FLAG_CUSTOM,
-    HWLOC_ALLOW_FLAG_LOCAL_RESTRICTIONS, HWLOC_RESTRICT_FLAG_ADAPT_IO,
-    HWLOC_RESTRICT_FLAG_ADAPT_MISC, HWLOC_RESTRICT_FLAG_BYNODESET,
-    HWLOC_RESTRICT_FLAG_REMOVE_CPULESS, HWLOC_RESTRICT_FLAG_REMOVE_MEMLESS,
+    HWLOC_ALLOW_FLAG_ALL, HWLOC_ALLOW_FLAG_CUSTOM, HWLOC_ALLOW_FLAG_LOCAL_RESTRICTIONS,
+    HWLOC_RESTRICT_FLAG_ADAPT_IO, HWLOC_RESTRICT_FLAG_ADAPT_MISC, HWLOC_RESTRICT_FLAG_BYNODESET,
+    HWLOC_RESTRICT_FLAG_REMOVE_CPULESS, HWLOC_RESTRICT_FLAG_REMOVE_MEMLESS, hwloc_restrict_flags_e,
+    hwloc_topology,
 };
 use libc::{EINVAL, ENOMEM, ENOSYS};
 #[allow(unused)]
@@ -121,7 +121,9 @@ impl Topology {
         });
         #[cfg(not(tarpaulin_include))]
         if let Err(e) = result {
-            eprintln!("ERROR: Failed to refresh topology ({e}), so it's stuck in a state that violates Rust aliasing rules. Must abort...");
+            eprintln!(
+                "ERROR: Failed to refresh topology ({e}), so it's stuck in a state that violates Rust aliasing rules. Must abort..."
+            );
             std::process::abort()
         }
 
@@ -1633,8 +1635,8 @@ mod tests {
     use super::*;
     use crate::{
         object::{
-            depth::{Depth, NormalDepth},
             TopologyObjectID,
+            depth::{Depth, NormalDepth},
         },
         strategies::{any_object, any_string, topology_related_set},
     };
@@ -2605,9 +2607,11 @@ mod tests {
             let obj = res.unwrap();
             prop_assert_eq!(obj.object_type(), ObjectType::Misc);
             prop_assert_eq!(obj.name().unwrap().to_str().unwrap(), name);
-            prop_assert!(parent
-                .misc_children()
-                .any(|child| child.global_persistent_index() == obj.global_persistent_index()));
+            prop_assert!(
+                parent
+                    .misc_children()
+                    .any(|child| child.global_persistent_index() == obj.global_persistent_index())
+            );
             Ok(())
         })?;
         Ok(topology)

--- a/src/topology/export/synthetic.rs
+++ b/src/topology/export/synthetic.rs
@@ -14,15 +14,15 @@ use crate::{
 };
 use bitflags::bitflags;
 use hwlocality_sys::{
-    hwloc_topology_export_synthetic_flags_e, HWLOC_TOPOLOGY_EXPORT_SYNTHETIC_FLAG_IGNORE_MEMORY,
+    HWLOC_TOPOLOGY_EXPORT_SYNTHETIC_FLAG_IGNORE_MEMORY,
     HWLOC_TOPOLOGY_EXPORT_SYNTHETIC_FLAG_NO_ATTRS,
     HWLOC_TOPOLOGY_EXPORT_SYNTHETIC_FLAG_NO_EXTENDED_TYPES,
-    HWLOC_TOPOLOGY_EXPORT_SYNTHETIC_FLAG_V1,
+    HWLOC_TOPOLOGY_EXPORT_SYNTHETIC_FLAG_V1, hwloc_topology_export_synthetic_flags_e,
 };
 #[allow(unused)]
 #[cfg(test)]
 use similar_asserts::assert_eq;
-use std::ffi::{c_char, CString};
+use std::ffi::{CString, c_char};
 
 /// # Exporting Topologies to Synthetic
 //
@@ -139,7 +139,7 @@ mod tests {
     use super::*;
     use crate::{
         object::types::ObjectType,
-        topology::{builder::TypeFilter, TopologyObject},
+        topology::{TopologyObject, builder::TypeFilter},
     };
     use proptest::prelude::*;
     #[allow(unused)]

--- a/src/topology/export/xml.rs
+++ b/src/topology/export/xml.rs
@@ -12,14 +12,14 @@ use crate::{
     topology::Topology,
 };
 use bitflags::bitflags;
-use hwlocality_sys::{hwloc_topology_export_xml_flags_e, HWLOC_TOPOLOGY_EXPORT_XML_FLAG_V1};
+use hwlocality_sys::{HWLOC_TOPOLOGY_EXPORT_XML_FLAG_V1, hwloc_topology_export_xml_flags_e};
 #[allow(unused)]
 #[cfg(test)]
 use similar_asserts::assert_eq;
 use std::{
     borrow::Borrow,
     cmp::Ordering,
-    ffi::{c_char, c_uint, CStr, OsStr},
+    ffi::{CStr, OsStr, c_char, c_uint},
     fmt::{self, Debug, Display},
     hash::Hash,
     ops::{Deref, Index},

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -25,16 +25,16 @@ use crate::{
     ffi::transparent::AsNewtype,
     memory::nodeset::NodeSet,
     object::{
+        TopologyObject,
         depth::{Depth, NormalDepth},
         types::ObjectType,
-        TopologyObject,
     },
 };
 use bitflags::bitflags;
 use errno::Errno;
 use hwlocality_sys::{
-    hwloc_bitmap_s, hwloc_distrib_flags_e, hwloc_topology, hwloc_type_filter_e,
-    HWLOC_DISTRIB_FLAG_REVERSE,
+    HWLOC_DISTRIB_FLAG_REVERSE, hwloc_bitmap_s, hwloc_distrib_flags_e, hwloc_topology,
+    hwloc_type_filter_e,
 };
 use libc::EINVAL;
 #[allow(unused)]
@@ -986,7 +986,9 @@ impl Clone for Topology {
             // SAFETY: - Topology is trusted to contain a valid ptr (type invariant)
             //         - Topology will not be usable again after Drop
             unsafe { hwlocality_sys::hwloc_topology_destroy(clone.as_ptr()) }
-            panic!("ERROR: Failed to refresh topology clone ({e}), so it's stuck in a state that violates Rust aliasing rules...");
+            panic!(
+                "ERROR: Failed to refresh topology clone ({e}), so it's stuck in a state that violates Rust aliasing rules..."
+            );
         }
         Self(clone)
     }

--- a/src/topology/support.rs
+++ b/src/topology/support.rs
@@ -9,7 +9,7 @@
 // - Struct: https://hwloc.readthedocs.io/en/stable/structhwloc__topology__support.html
 
 #[cfg(doc)]
-use super::{builder::BuildFlags, Topology};
+use super::{Topology, builder::BuildFlags};
 use crate::ffi::{
     self,
     transparent::{AsNewtype, TransparentNewtype},
@@ -210,7 +210,14 @@ impl Arbitrary for DiscoverySupport {
     fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
         let b = crate::strategies::hwloc_bool();
         [b.clone(), b.clone(), b.clone(), b.clone(), b.clone(), b].prop_map(
-            |([pu, numa, numa_memory, disallowed_pu, disallowed_numa, cpukind_efficiency])| {
+            |([
+                pu,
+                numa,
+                numa_memory,
+                disallowed_pu,
+                disallowed_numa,
+                cpukind_efficiency,
+            ])| {
                 Self(hwloc_topology_discovery_support {
                     pu,
                     numa,
@@ -339,9 +346,19 @@ impl Arbitrary for CpuBindingSupport {
     fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
         let b = crate::strategies::hwloc_bool();
         [
-            b.clone(), b.clone(), b.clone(), b.clone(), b.clone(), b.clone(),
-            b.clone(), b.clone(), b.clone(), b.clone(), b
-        ].prop_map(
+            b.clone(),
+            b.clone(),
+            b.clone(),
+            b.clone(),
+            b.clone(),
+            b.clone(),
+            b.clone(),
+            b.clone(),
+            b.clone(),
+            b.clone(),
+            b,
+        ]
+        .prop_map(
             |([
                 set_thisproc_cpubind,
                 get_thisproc_cpubind,
@@ -353,7 +370,7 @@ impl Arbitrary for CpuBindingSupport {
                 get_thread_cpubind,
                 get_thisproc_last_cpu_location,
                 get_proc_last_cpu_location,
-                get_thisthread_last_cpu_location
+                get_thisthread_last_cpu_location,
             ])| {
                 Self(hwloc_topology_cpubind_support {
                     set_thisproc_cpubind,
@@ -712,8 +729,8 @@ mod tests {
     );
 
     #[cfg(not(feature = "hwloc-2_3_0"))]
-    fn support_components(
-    ) -> impl Strategy<Value = (DiscoverySupport, CpuBindingSupport, MemoryBindingSupport)> {
+    fn support_components()
+    -> impl Strategy<Value = (DiscoverySupport, CpuBindingSupport, MemoryBindingSupport)> {
         any::<(DiscoverySupport, CpuBindingSupport, MemoryBindingSupport)>()
     }
 

--- a/tests/single-threaded.rs
+++ b/tests/single-threaded.rs
@@ -8,6 +8,7 @@
 
 use errno::Errno;
 use hwlocality::{
+    ProcessId,
     bitmap::{Bitmap, BitmapIndex, BitmapKind, BitmapRef, SpecializedBitmap, SpecializedBitmapRef},
     cpu::{
         binding::{CpuBindingError, CpuBindingFlags, CpuBoundObject},
@@ -22,10 +23,9 @@ use hwlocality::{
         nodeset::NodeSet,
     },
     topology::{
-        support::{FeatureSupport, MemoryBindingSupport},
         Topology,
+        support::{FeatureSupport, MemoryBindingSupport},
     },
-    ProcessId,
 };
 use proptest::{prelude::*, test_runner::TestRunner};
 use std::{


### PR DESCRIPTION
The latest sha3 release requires rustc  v1.85, which is also required by some of our other dependencies and beyond our "1 year old" psychological threshold for an old enough MSRV. So let's do this update.

Along the way, rust 1.85 also allows us to switch to edition 2024, which features a number of nice polishing touches. So we perform the edition switch too.